### PR TITLE
Adding Stock or ETF name as a tooltip/title in HTML

### DIFF
--- a/.github/workflows/portfolio-monitor.yml
+++ b/.github/workflows/portfolio-monitor.yml
@@ -2,13 +2,19 @@ name: Portfolio Monitor
 
 on:
   schedule:
-    # Daily morning: 10pm UTC = 8am AEST (next day)
-    - cron: "0 22 * * *"
-    # Intraday checks: weekdays only (Mon-Fri)
-    - cron: "0 0 * * 1-5"    # 10am AEST
-    - cron: "0 2 * * 1-5"    # 12pm AEST
-    - cron: "0 4 * * 1-5"    # 2pm AEST
-    - cron: "0 6 * * 1-5"    # 4pm AEST
+    # Daily morning: 8am UTC (next day)
+    # - cron: "0 8 * * *" 
+    # Daily morning: 7am BST = 8am UTC
+    - cron: "0 7 * * *"
+    # Intraday checks: weekdays only (Mon-Fri) - UTC
+    # - cron: "0 10 * * 1-5"    # 10am UTC
+    # - cron: "0 12 * * 1-5"    # 12pm UTC
+    # - cron: "0 14 * * 1-5"    # 2pm UTC
+    # - cron: "0 16 * * 1-5"    # 4pm UTC
+    - cron: "0 9 * * 1-5"    # 10am BST/9am UTC
+    - cron: "0 11 * * 1-5"    # 12pm BST/11am UTC
+    - cron: "0 13 * * 1-5"    # 2pm BST/1pm UTC
+    - cron: "0 15 * * 1-5"    # 4pm BST/3pm UTC
   workflow_dispatch:
     inputs:
       mode:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richfolio",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "richfolio",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@google/genai": "^1.42.0",

--- a/src/aiAnalysis.ts
+++ b/src/aiAnalysis.ts
@@ -33,6 +33,7 @@ const LONG_DURATION_BOND_ETFS = new Set([
 // ── Types ───────────────────────────────────────────────────────────
 export interface AIBuyRecommendation {
   ticker: string;
+  tickerFullName: string | null;
   action: string;
   confidence: number;
   reason: string;
@@ -126,9 +127,10 @@ function buildPrompt(
     const ticker = item.ticker.toUpperCase();
     const isShortBond = SHORT_DURATION_BOND_ETFS.has(ticker);
     const isLongBond = LONG_DURATION_BOND_ETFS.has(ticker);
+    const fullName = item.tickerFullName || item.ticker;
 
     const lines = [
-      `${item.ticker}:`,
+      `${item.ticker} (${fullName}):`,
       isShortBond ? `  Asset type: SHORT-DURATION BOND ETF (1-5 year, ~2% price range — apply framework 12a)` : null,
       isLongBond ? `  Asset type: LONG/INTERMEDIATE-DURATION BOND ETF (rate-sensitive, can rally on rate cuts — apply framework 12b)` : null,
       `  Price: $${item.price.toFixed(2)}`,
@@ -222,6 +224,7 @@ TICKER DATA:
 ${tickerSummaries.join("\n\n")}
 
 INSTRUCTIONS:
+0. IMPORTANT: When writing reasons and discussing tickers, use the full company/ETF name provided in parentheses, not generic phrases like "This ETF" or "The stock". Always refer to tickers by their full name when appropriate (e.g., "Microsoft is oversold" instead of "This stock is oversold").
 1. Only recommend tickers that are in the target portfolio (target > 0%).
 2. Prioritize tickers that have BOTH allocation need AND good entry price. A small gap with excellent valuation (low P/E, near 52w low) should rank ABOVE a large gap with poor valuation (high P/E, near 52w high).
 3. Consider news sentiment — negative news may mean a buying opportunity (contrarian) or genuine risk.
@@ -351,6 +354,12 @@ export async function aiAnalyze(
     const recommendations = JSON.parse(
       response.text ?? "[]"
     ) as AIBuyRecommendation[];
+
+    // Enrich with tickerFullName from allocation report
+    const tickerFullNameMap = new Map(report.items.map((item) => [item.ticker, item.tickerFullName]));
+    for (const rec of recommendations) {
+      rec.tickerFullName = tickerFullNameMap.get(rec.ticker) ?? null;
+    }
 
     // Hard cap: short-duration bond ETFs can never be STRONG BUY (no capital appreciation upside)
     for (const rec of recommendations) {

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -8,6 +8,7 @@ import type { QuoteData } from "./fetchPrices.js";
 // ── Types ───────────────────────────────────────────────────────────
 export interface AllocationItem {
   ticker: string;
+  tickerFullName: string | null;
   currentShares: number;
   currentValue: number;
   currentPct: number;
@@ -117,6 +118,7 @@ export function runAnalysis(
 
     items.push({
       ticker,
+      tickerFullName: quote.name ?? null,
       currentShares: shares,
       currentValue: value,
       currentPct: Math.round(currentPct * 100) / 100,

--- a/src/detailedAnalysis.ts
+++ b/src/detailedAnalysis.ts
@@ -48,7 +48,7 @@ function buildDetailedPrompt(
   const lines = [
     `You are a senior investment analyst writing a detailed buy recommendation for a client.`,
     ``,
-    `TICKER: ${ticker}`,
+    `TICKER: ${ticker}${rec.tickerFullName ? ` (${rec.tickerFullName})` : ""}`,
     `Current price: $${quote.price.toFixed(2)}`,
     `Trailing P/E: ${quote.trailingPE?.toFixed(1) ?? "N/A"} | Forward P/E: ${quote.forwardPE?.toFixed(1) ?? "N/A"} | Avg P/E: ${quote.avgPE?.toFixed(1) ?? "N/A"}`,
     (() => {
@@ -112,6 +112,7 @@ function buildDetailedPrompt(
   lines.push("4. Portfolio fit (allocation need, diversification benefit)");
   lines.push("");
   lines.push("CRITICAL RULES:");
+  lines.push("- Use the full company/ETF name (provided above) in your thesis, not generic phrases like \"This ETF\" or \"The stock\". Reference by full name when appropriate.");
   lines.push("- The 52-week position percentage is the position WITHIN the annual range (0%=at 52w low, 100%=at 52w high). Do NOT describe it as '% of 52-week high' — that is a different number. Use the explicit '% below 52w high' value provided.");
   lines.push("- If price is below the 200-day MA, do NOT cite a golden cross as bullish — it is a lagging artifact when price has already fallen below the long-term trend.");
   lines.push("");

--- a/src/email.ts
+++ b/src/email.ts
@@ -152,7 +152,7 @@ function buildAISection(aiRecs: AIBuyRecommendation[], technicals: Record<string
   ${actionable.length > 0 ? actionable.map((rec) => `
   <div style="padding:10px 0;border-bottom:1px solid ${S.border};">
     <div style="margin-bottom:4px;">
-      <span style="font-weight:bold;font-size:14px;color:#fff;">${rec.ticker}</span>
+      <span style="font-weight:bold;font-size:14px;color:#fff;" title="${rec.tickerFullName || rec.ticker}">${rec.ticker}</span>
       &nbsp;${actionBadge(rec.action)}${valueRatingBadge(rec.valueRating)}
       &nbsp;${confidenceBar(rec.confidence)}
       ${rec.suggestedBuyValue > 0 ? `<span style="float:right;font-weight:bold;color:#fff;">${fmt$(rec.suggestedBuyValue)}</span>` : ""}
@@ -169,7 +169,7 @@ function buildAISection(aiRecs: AIBuyRecommendation[], technicals: Record<string
     <div style="font-size:11px;color:${S.muted};text-transform:uppercase;margin-bottom:6px;">Hold / Wait</div>
     ${others.map((rec) => `
     <div style="padding:4px 0;font-size:12px;">
-      <span style="font-weight:bold;">${rec.ticker}</span>
+      <span style="font-weight:bold;" title="${rec.tickerFullName || rec.ticker}">${rec.ticker}</span>
       &nbsp;${actionBadge(rec.action)}${valueRatingBadge(rec.valueRating)}
       <span style="color:${S.muted};margin-left:8px;">${rec.reason}</span>
     </div>`).join("")}
@@ -199,7 +199,7 @@ function buildFallbackBuysSection(report: AllocationReport): string {
     </tr>
     ${buys.map((b) => `
     <tr>
-      <td style="padding:6px 4px;border-bottom:1px solid ${S.border};font-weight:bold;">${b.ticker}</td>
+      <td style="padding:6px 4px;border-bottom:1px solid ${S.border};font-weight:bold;" title="${b.tickerFullName || b.ticker}">${b.ticker}</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:right;color:${S.red};">${fmtPct(b.gapPct)}</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:right;">${b.suggestedBuyShares.toFixed(1)}</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:right;">${fmt$(b.suggestedBuyValue)}${b.overlapDiscount > 0 ? `<div style="font-size:10px;color:${S.muted};">-${fmt$(b.overlapDiscount)} overlap</div>` : ""}</td>
@@ -283,7 +283,7 @@ ${buysSection}
     </tr>
     ${report.items.map((item) => `
     <tr>
-      <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-weight:bold;">${item.ticker}</td>
+      <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-weight:bold;" title="${item.tickerFullName || item.ticker}">${item.ticker}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">$${item.price.toLocaleString("en-US", { maximumFractionDigits: 2 })}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">${item.currentPct.toFixed(1)}%</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">${item.targetPct.toFixed(1)}%</td>

--- a/src/fetchPrices.ts
+++ b/src/fetchPrices.ts
@@ -105,7 +105,7 @@ async function fetchOne(yahooTicker: string): Promise<QuoteData | null> {
 
     return {
       ticker: configTicker,
-      name: result.price?.shortName ?? result.price?.longName ?? null,
+      name: result.price?.longName ?? result.price?.shortName ?? null,
       price,
       trailingPE: result.summaryDetail?.trailingPE ?? null,
       forwardPE: result.summaryDetail?.forwardPE ?? null,

--- a/src/intradayCompare.ts
+++ b/src/intradayCompare.ts
@@ -5,6 +5,7 @@ import type { IntradayAlertConfig } from "./config.js";
 // ── Types ───────────────────────────────────────────────────────────
 export interface IntradayAlert {
   ticker: string;
+  tickerFullName: string | null;
   morningAction: string;
   morningConfidence: number;
   currentAction: string;
@@ -84,6 +85,7 @@ export function compareWithBaseline(
     if (triggerType) {
       alerts.push({
         ticker: rec.ticker,
+        tickerFullName: rec.tickerFullName ?? null,
         morningAction,
         morningConfidence,
         currentAction: rec.action,

--- a/src/intradayEmail.ts
+++ b/src/intradayEmail.ts
@@ -99,7 +99,7 @@ export function buildIntradayEmailHtml(alerts: IntradayAlert[]): string {
       (a) => `
   <div style="padding:14px 0;border-bottom:1px solid ${S.border};">
     <div style="margin-bottom:6px;">
-      <span style="font-weight:bold;font-size:16px;color:#fff;">${a.ticker}</span>
+      <span style="font-weight:bold;font-size:16px;color:#fff;" title="${a.tickerFullName || a.ticker}">${a.ticker}</span>
       &nbsp;${actionBadge(a.currentAction)}${valueRatingBadge(a.valueRating)}
       <span style="float:right;font-size:11px;color:${S.yellow};text-transform:uppercase;">${triggerLabel(a.triggerType)}</span>
     </div>

--- a/src/weeklyEmail.ts
+++ b/src/weeklyEmail.ts
@@ -103,7 +103,7 @@ export function buildWeeklyEmailHtml(report: AllocationReport): string {
       const action = actionLabel(item.gapPct);
       return `
     <tr>
-      <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-weight:bold;">${item.ticker}</td>
+      <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-weight:bold;" title="${item.tickerFullName || item.ticker}">${item.ticker}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:center;">
         <span style="background:${action.color};color:#000;padding:1px 6px;border-radius:3px;font-size:10px;font-weight:bold;">${action.text}</span>
       </td>


### PR DESCRIPTION
Hello
I have added a property to enable the email to offer the full name of the stock or ETF to make it easier to identify the asset.

For stocks this is less of an issue, but for ETFs I find that the SEDOL is actually quite unclear about what the item actually is.
E.g. 0P000102ME.L if using just Ticker. When there are many similar ETFs it's impossible to tell which is which at a glance. So now it will actually show a tooltip on the Ticker name: 'L&G UK Index C Acc'.
