### PR TITLE
Add ticker name tooltips + external-PR CI gate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Format check
+        run: npm run format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+state
+docs
+*.md
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "endOfLine": "lf"
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # Richfolio
 
+[![CI](https://github.com/furic/richfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/furic/richfolio/actions/workflows/ci.yml)
 [![Portfolio Monitor](https://github.com/furic/richfolio/actions/workflows/portfolio-monitor.yml/badge.svg)](https://github.com/furic/richfolio/actions/workflows/portfolio-monitor.yml)
 [![Docs](https://github.com/furic/richfolio/actions/workflows/docs.yml/badge.svg)](https://furic.github.io/richfolio/)
 [![Node.js](https://img.shields.io/badge/Node.js-22%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.3.0",
+        "prettier": "^3.3.3",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       }
@@ -1330,6 +1331,22 @@
       "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
       "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==",
       "license": "MIT-0"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/protobufjs": {
       "version": "7.5.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "dev": "tsx src/index.ts",
     "weekly": "tsx src/index.ts --weekly",
     "intraday": "tsx src/index.ts --intraday",
-    "refresh": "tsx src/index.ts --refresh"
+    "refresh": "tsx src/index.ts --refresh",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\""
   },
   "repository": {
     "type": "git",
@@ -42,6 +45,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.3.0",
+    "prettier": "^3.3.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }

--- a/src/aiAnalysis.ts
+++ b/src/aiAnalysis.ts
@@ -11,8 +11,16 @@ const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 // Short-duration bond ETFs (1-5 year) — essentially cash equivalents, ~2% annual price range.
 // No equity-style upside. Hard cap at BUY — STRONG BUY is never appropriate here.
 const SHORT_DURATION_BOND_ETFS = new Set([
-  "BSV", "SHY", "VGSH", "SCHO", "BIL", "SHV", "CLTL", "SGOV",
-  "VCSH", "USIG",
+  "BSV",
+  "SHY",
+  "VGSH",
+  "SCHO",
+  "BIL",
+  "SHV",
+  "CLTL",
+  "SGOV",
+  "VCSH",
+  "USIG",
 ]);
 
 // Long/intermediate-duration bond ETFs — rate-sensitive, can rally 20-30% when rates drop.
@@ -20,21 +28,37 @@ const SHORT_DURATION_BOND_ETFS = new Set([
 // But RSI/MACD/momentum are still NOT the right signals — rate environment is.
 const LONG_DURATION_BOND_ETFS = new Set([
   // Intermediate government
-  "BND", "AGG", "IEF", "VGIT", "GOVT", "GVI",
+  "BND",
+  "AGG",
+  "IEF",
+  "VGIT",
+  "GOVT",
+  "GVI",
   // Long-term government
-  "TLT", "EDV", "VGLT", "TLH",
+  "TLT",
+  "EDV",
+  "VGLT",
+  "TLH",
   // Corporate (intermediate/long)
-  "LQD", "VCIT", "VCLT", "HYG", "JNK",
+  "LQD",
+  "VCIT",
+  "VCLT",
+  "HYG",
+  "JNK",
   // TIPS / inflation-protected
-  "TIP", "SCHP", "VTIP", "STIP",
+  "TIP",
+  "SCHP",
+  "VTIP",
+  "STIP",
   // International
-  "BNDX", "IAGG",
+  "BNDX",
+  "IAGG",
 ]);
-
 
 // ── Types ───────────────────────────────────────────────────────────
 export interface AIBuyRecommendation {
   ticker: string;
+  tickerFullName: string | null;
   action: string;
   confidence: number;
   reason: string;
@@ -91,8 +115,7 @@ const observationSchema = {
       },
       allocationContext: {
         type: Type.STRING,
-        description:
-          "1-sentence allocation context: gap %, direction, and dollar amount needed",
+        description: "1-sentence allocation context: gap %, direction, and dollar amount needed",
       },
     },
     propertyOrdering: [
@@ -132,8 +155,7 @@ const responseSchema = {
       },
       action: {
         type: Type.STRING,
-        description:
-          "One of: STRONG BUY, BUY, HOLD, WAIT",
+        description: "One of: STRONG BUY, BUY, HOLD, WAIT",
       },
       confidence: {
         type: Type.NUMBER,
@@ -141,8 +163,7 @@ const responseSchema = {
       },
       reason: {
         type: Type.STRING,
-        description:
-          "1-2 sentence explanation of why this action is recommended",
+        description: "1-2 sentence explanation of why this action is recommended",
       },
       suggestedBuyValue: {
         type: Type.NUMBER,
@@ -190,7 +211,7 @@ function buildPrompt(
   priceData: Record<string, QuoteData>,
   news: Record<string, NewsItem[]>,
   technicals: Record<string, TechnicalData> = {},
-  macroContext: string = ""
+  macroContext: string = "",
 ): string {
   const tickerSummaries = report.items.map((item) => {
     const quote = priceData[item.ticker];
@@ -206,83 +227,128 @@ function buildPrompt(
     const ticker = item.ticker.toUpperCase();
     const isShortBond = SHORT_DURATION_BOND_ETFS.has(ticker);
     const isLongBond = LONG_DURATION_BOND_ETFS.has(ticker);
+    const fullName = item.tickerFullName || item.ticker;
 
     const lines = [
-      `${item.ticker}:`,
-      isShortBond ? `  Asset type: SHORT-DURATION BOND ETF (1-5 year, ~2% price range — apply framework 12a)` : null,
-      isLongBond ? `  Asset type: LONG/INTERMEDIATE-DURATION BOND ETF (rate-sensitive, can rally on rate cuts — apply framework 12b)` : null,
+      `${item.ticker} (${fullName}):`,
+      isShortBond
+        ? `  Asset type: SHORT-DURATION BOND ETF (1-5 year, ~2% price range — apply framework 12a)`
+        : null,
+      isLongBond
+        ? `  Asset type: LONG/INTERMEDIATE-DURATION BOND ETF (rate-sensitive, can rally on rate cuts — apply framework 12b)`
+        : null,
       `  Price: $${item.price.toFixed(2)}`,
       `  Trailing P/E: ${quote?.trailingPE?.toFixed(1) ?? "N/A"}`,
       `  Forward P/E: ${quote?.forwardPE?.toFixed(1) ?? "N/A"}`,
       `  Avg P/E (historical): ${quote?.avgPE?.toFixed(1) ?? "N/A"}`,
       (() => {
-        const wpPct = item.fiftyTwoWeekPercent != null ? Math.round(item.fiftyTwoWeekPercent * 100) : null;
-        const belowHigh = quote?.fiftyTwoWeekHigh != null
-          ? ((quote.fiftyTwoWeekHigh - item.price) / quote.fiftyTwoWeekHigh * 100).toFixed(1)
-          : null;
-        const aboveLow = quote?.fiftyTwoWeekLow != null
-          ? ((item.price - quote.fiftyTwoWeekLow) / quote.fiftyTwoWeekLow * 100).toFixed(1)
-          : null;
+        const wpPct =
+          item.fiftyTwoWeekPercent != null ? Math.round(item.fiftyTwoWeekPercent * 100) : null;
+        const belowHigh =
+          quote?.fiftyTwoWeekHigh != null
+            ? (((quote.fiftyTwoWeekHigh - item.price) / quote.fiftyTwoWeekHigh) * 100).toFixed(1)
+            : null;
+        const aboveLow =
+          quote?.fiftyTwoWeekLow != null
+            ? (((item.price - quote.fiftyTwoWeekLow) / quote.fiftyTwoWeekLow) * 100).toFixed(1)
+            : null;
         if (wpPct == null) return `  52-week position: N/A`;
-        const qualifier = wpPct < 20 ? " ← NEAR ANNUAL LOW" : wpPct > 70 ? " ← NEAR ANNUAL HIGH" : "";
-        return `  52-week position: ${wpPct}% of annual range (0%=at 52w low, 100%=at 52w high)${qualifier}` +
+        const qualifier =
+          wpPct < 20 ? " ← NEAR ANNUAL LOW" : wpPct > 70 ? " ← NEAR ANNUAL HIGH" : "";
+        return (
+          `  52-week position: ${wpPct}% of annual range (0%=at 52w low, 100%=at 52w high)${qualifier}` +
           (belowHigh != null ? `; ${belowHigh}% below 52w high` : "") +
-          (aboveLow != null ? `; ${aboveLow}% above 52w low` : "");
+          (aboveLow != null ? `; ${aboveLow}% above 52w low` : "")
+        );
       })(),
       `  Dividend yield: ${item.dividendYield != null ? (item.dividendYield * 100).toFixed(2) + "%" : "N/A"}`,
       `  Beta: ${item.beta?.toFixed(2) ?? "N/A"}`,
       (() => {
         const days = quote?.daysToEarnings;
         if (days == null) return `  Earnings: none upcoming`;
-        const dateStr = quote?.earningsDate ? quote.earningsDate.toISOString().split("T")[0] : "unknown";
+        const dateStr = quote?.earningsDate
+          ? quote.earningsDate.toISOString().split("T")[0]
+          : "unknown";
         const warning = days <= 3 ? " ⚠ IMMINENT" : days <= 7 ? " ⚠ SOON" : "";
         return `  Earnings: in ${days} days (${dateStr})${warning}`;
       })(),
       `  Current allocation: ${item.currentPct.toFixed(1)}% (target: ${item.targetPct.toFixed(1)}%, gap: ${item.gapPct > 0 ? "+" : ""}${item.gapPct.toFixed(1)}%)`,
-      item.suggestedBuyValue > 0 ? `  Calculated gap amount: $${item.suggestedBuyValue.toFixed(0)} (full amount needed to close allocation gap)` : null,
-      item.overlapDiscount > 0 ? `  ETF overlap discount: -$${item.overlapDiscount.toFixed(0)} (${item.overlapPct.toFixed(0)}% of gap covered by held stocks)` : null,
+      item.suggestedBuyValue > 0
+        ? `  Calculated gap amount: $${item.suggestedBuyValue.toFixed(0)} (full amount needed to close allocation gap)`
+        : null,
+      item.overlapDiscount > 0
+        ? `  ETF overlap discount: -$${item.overlapDiscount.toFixed(0)} (${item.overlapPct.toFixed(0)}% of gap covered by held stocks)`
+        : null,
       `  P/E signal: ${item.peSignal ?? "none"}`,
     ];
 
     if (tech) {
       lines.push(`  Technical indicators:`);
-      lines.push(`    50-day MA: $${tech.sma50} (price ${tech.priceVsSma50 > 0 ? "+" : ""}${tech.priceVsSma50}% vs MA)`);
+      lines.push(
+        `    50-day MA: $${tech.sma50} (price ${tech.priceVsSma50 > 0 ? "+" : ""}${tech.priceVsSma50}% vs MA)`,
+      );
       if (tech.sma200 != null) {
-        lines.push(`    200-day MA: $${tech.sma200} (price ${tech.priceVsSma200! > 0 ? "+" : ""}${tech.priceVsSma200}% vs MA)`);
+        lines.push(
+          `    200-day MA: $${tech.sma200} (price ${tech.priceVsSma200! > 0 ? "+" : ""}${tech.priceVsSma200}% vs MA)`,
+        );
       }
       lines.push(`    RSI(14): ${tech.rsi14} (>70 overbought, <30 oversold)`);
-      lines.push(`    Momentum: ${tech.momentumSignal}${tech.goldenCross ? " (golden cross)" : ""}${tech.deathCross ? " (death cross)" : ""}`);
+      lines.push(
+        `    Momentum: ${tech.momentumSignal}${tech.goldenCross ? " (golden cross)" : ""}${tech.deathCross ? " (death cross)" : ""}`,
+      );
       // MACD
       if (tech.macd != null && tech.macdSignal != null) {
-        lines.push(`    MACD: ${tech.macd} / signal: ${tech.macdSignal} / histogram: ${tech.macdHistogram}${tech.macdCrossover ? ` (${tech.macdCrossover} crossover)` : ""}`);
+        lines.push(
+          `    MACD: ${tech.macd} / signal: ${tech.macdSignal} / histogram: ${tech.macdHistogram}${tech.macdCrossover ? ` (${tech.macdCrossover} crossover)` : ""}`,
+        );
       }
       // Bollinger Bands
       if (tech.bollMiddle != null) {
-        lines.push(`    Bollinger Bands: $${tech.bollLower} / $${tech.bollMiddle} / $${tech.bollUpper} (%B=${tech.bollPercentB}, BW=${tech.bollBandwidth})${tech.bollSqueeze ? " (SQUEEZE — low volatility, breakout likely)" : ""}`);
+        lines.push(
+          `    Bollinger Bands: $${tech.bollLower} / $${tech.bollMiddle} / $${tech.bollUpper} (%B=${tech.bollPercentB}, BW=${tech.bollBandwidth})${tech.bollSqueeze ? " (SQUEEZE — low volatility, breakout likely)" : ""}`,
+        );
       }
       // ATR
       if (tech.atr14 != null) {
-        const volLevel = tech.atrPercent! > 3 ? "high volatility — widen limit orders" : tech.atrPercent! < 1 ? "low volatility — tighter limits" : "moderate volatility";
+        const volLevel =
+          tech.atrPercent! > 3
+            ? "high volatility — widen limit orders"
+            : tech.atrPercent! < 1
+              ? "low volatility — tighter limits"
+              : "moderate volatility";
         lines.push(`    ATR(14): $${tech.atr14} (${tech.atrPercent}% of price — ${volLevel})`);
       }
       // Stochastic
       if (tech.stochK != null) {
-        const stochLevel = tech.stochK < 20 ? " ← OVERSOLD" : tech.stochK > 80 ? " ← OVERBOUGHT" : "";
-        lines.push(`    Stochastic: %K=${tech.stochK}, %D=${tech.stochD} (<20 oversold, >80 overbought)${stochLevel}`);
+        const stochLevel =
+          tech.stochK < 20 ? " ← OVERSOLD" : tech.stochK > 80 ? " ← OVERBOUGHT" : "";
+        lines.push(
+          `    Stochastic: %K=${tech.stochK}, %D=${tech.stochD} (<20 oversold, >80 overbought)${stochLevel}`,
+        );
       }
       // OBV
       if (tech.obvTrend != null) {
-        const obvLabel = tech.obvTrend === "rising" ? "accumulation" : tech.obvTrend === "falling" ? "distribution" : "neutral";
+        const obvLabel =
+          tech.obvTrend === "rising"
+            ? "accumulation"
+            : tech.obvTrend === "falling"
+              ? "distribution"
+              : "neutral";
         lines.push(`    OBV trend: ${tech.obvTrend} (${obvLabel})`);
       }
       lines.push(`    7-day low: $${tech.recentLow7d}, 30-day low: $${tech.recentLow30d}`);
       if (tech.volumeChange7d != null) {
-        lines.push(`    Volume change (7d vs 30d avg): ${tech.volumeChange7d > 0 ? "+" : ""}${tech.volumeChange7d}%${tech.volumeChange7d < -20 ? " (contraction)" : tech.volumeChange7d > 50 ? " (surge)" : ""}`);
+        lines.push(
+          `    Volume change (7d vs 30d avg): ${tech.volumeChange7d > 0 ? "+" : ""}${tech.volumeChange7d}%${tech.volumeChange7d < -20 ? " (contraction)" : tech.volumeChange7d > 50 ? " (surge)" : ""}`,
+        );
       }
     }
 
     // Fundamental data (stocks only — null for ETFs/crypto)
-    if (quote && (quote.returnOnEquity != null || quote.debtToEquity != null || quote.freeCashflow != null)) {
+    if (
+      quote &&
+      (quote.returnOnEquity != null || quote.debtToEquity != null || quote.freeCashflow != null)
+    ) {
       lines.push(`  Fundamentals:`);
       if (quote.returnOnEquity != null) {
         lines.push(`    ROE: ${(quote.returnOnEquity * 100).toFixed(1)}% (>15% is strong)`);
@@ -290,9 +356,15 @@ function buildPrompt(
       if (quote.debtToEquity != null) {
         lines.push(`    Debt/Equity: ${quote.debtToEquity.toFixed(1)}% (<50% is conservative)`);
       }
-      if (quote.freeCashflow != null && quote.operatingCashflow != null && quote.operatingCashflow > 0) {
+      if (
+        quote.freeCashflow != null &&
+        quote.operatingCashflow != null &&
+        quote.operatingCashflow > 0
+      ) {
         const fcfRatio = (quote.freeCashflow / quote.operatingCashflow) * 100;
-        lines.push(`    FCF/Operating CF: ${fcfRatio.toFixed(0)}% (>80% shows strong cash conversion)`);
+        lines.push(
+          `    FCF/Operating CF: ${fcfRatio.toFixed(0)}% (>80% shows strong cash conversion)`,
+        );
       }
       if (quote.profitMargins != null) {
         lines.push(`    Profit margin: ${(quote.profitMargins * 100).toFixed(1)}%`);
@@ -304,18 +376,27 @@ function buildPrompt(
         lines.push(`    Earnings growth: ${(quote.earningsGrowth * 100).toFixed(1)}% YoY`);
       }
       if (quote.targetMeanPrice != null) {
-        lines.push(`    Analyst target: $${quote.targetMeanPrice.toFixed(2)} (${quote.recommendationKey ?? "N/A"})`);
+        lines.push(
+          `    Analyst target: $${quote.targetMeanPrice.toFixed(2)} (${quote.recommendationKey ?? "N/A"})`,
+        );
       }
     }
 
     if (headlines) {
       lines.push(`  Recent news: ${headlines}`);
       // Compute overall sentiment from individual articles
-      const sentiments = newsItems.filter(n => n.sentiment).map(n => n.sentiment!);
+      const sentiments = newsItems.filter((n) => n.sentiment).map((n) => n.sentiment!);
       if (sentiments.length > 0) {
-        const bullish = sentiments.filter(s => s === "bullish").length;
-        const bearish = sentiments.filter(s => s === "bearish").length;
-        const overall = bullish > bearish ? "bullish" : bearish > bullish ? "bearish" : bullish === bearish && bullish > 0 ? "mixed" : "neutral";
+        const bullish = sentiments.filter((s) => s === "bullish").length;
+        const bearish = sentiments.filter((s) => s === "bearish").length;
+        const overall =
+          bullish > bearish
+            ? "bullish"
+            : bearish > bullish
+              ? "bearish"
+              : bullish === bearish && bullish > 0
+                ? "mixed"
+                : "neutral";
         lines.push(`  Overall news sentiment: ${overall}`);
       }
     } else {
@@ -337,6 +418,7 @@ ${tickerSummaries.join("\n\n")}
 
 INSTRUCTIONS:
 1. Only recommend tickers that are in the target portfolio (target > 0%).
+   When writing the reason field, use the full company/ETF name shown in parentheses next to each ticker (e.g. "Microsoft is oversold" rather than "this stock is oversold"). Do not invent or guess names — only use names that appear in the data.
 2. Prioritize tickers that have BOTH allocation need AND good entry price. A small gap with excellent valuation (low P/E, near 52w low) should rank ABOVE a large gap with poor valuation (high P/E, near 52w high).
 3. Consider news sentiment — negative news may mean a buying opportunity (contrarian) or genuine risk.
 4. For each ticker, assign:
@@ -449,7 +531,7 @@ function buildObservationPrompt(
   priceData: Record<string, QuoteData>,
   news: Record<string, NewsItem[]>,
   technicals: Record<string, TechnicalData> = {},
-  macroContext: string = ""
+  macroContext: string = "",
 ): string {
   // Reuse the same data block from buildPrompt
   const dataBlock = buildPrompt(report, priceData, news, technicals, macroContext);
@@ -497,33 +579,36 @@ function buildDecisionPrompt(
   observations: TickerObservation[],
   report: AllocationReport,
   macroContext: string = "",
-  reasoningContext: string = ""
+  reasoningContext: string = "",
 ): string {
   // Build key metrics per ticker so the decision stage has actual numbers for limit prices etc.
   const metricsMap: Record<string, string[]> = {};
   for (const item of report.items) {
     const lines: string[] = [];
     lines.push(`  Price: $${item.price.toFixed(2)}`);
-    if (item.fiftyTwoWeekPercent != null) lines.push(`  52w position: ${Math.round(item.fiftyTwoWeekPercent * 100)}%`);
+    if (item.fiftyTwoWeekPercent != null)
+      lines.push(`  52w position: ${Math.round(item.fiftyTwoWeekPercent * 100)}%`);
     lines.push(`  Gap: ${item.gapPct > 0 ? "+" : ""}${item.gapPct.toFixed(1)}%`);
     if (item.trailingPE != null) lines.push(`  P/E: ${item.trailingPE.toFixed(1)}`);
     metricsMap[item.ticker] = lines;
   }
 
-  const obsText = observations.map((obs) => {
-    const lines = [
-      `${obs.ticker}:`,
-      ...(metricsMap[obs.ticker] ?? []),
-      `  Price-level signals: ${obs.priceLevelSignals.length > 0 ? obs.priceLevelSignals.join(", ") : "none"}`,
-      `  Momentum signals: ${obs.momentumSignals.length > 0 ? obs.momentumSignals.join(", ") : "none"}`,
-      `  Risk flags: ${obs.riskFlags.length > 0 ? obs.riskFlags.join(", ") : "none"}`,
-      `  Valuation: ${obs.valueSummary}`,
-      `  Technical: ${obs.technicalSummary}`,
-      `  News: ${obs.newsSentiment}`,
-      `  Allocation: ${obs.allocationContext}`,
-    ];
-    return lines.join("\n");
-  }).join("\n\n");
+  const obsText = observations
+    .map((obs) => {
+      const lines = [
+        `${obs.ticker}:`,
+        ...(metricsMap[obs.ticker] ?? []),
+        `  Price-level signals: ${obs.priceLevelSignals.length > 0 ? obs.priceLevelSignals.join(", ") : "none"}`,
+        `  Momentum signals: ${obs.momentumSignals.length > 0 ? obs.momentumSignals.join(", ") : "none"}`,
+        `  Risk flags: ${obs.riskFlags.length > 0 ? obs.riskFlags.join(", ") : "none"}`,
+        `  Valuation: ${obs.valueSummary}`,
+        `  Technical: ${obs.technicalSummary}`,
+        `  News: ${obs.newsSentiment}`,
+        `  Allocation: ${obs.allocationContext}`,
+      ];
+      return lines.join("\n");
+    })
+    .join("\n\n");
 
   // Find gap amounts from the report for suggestedBuyValue sizing guidance
   const gapMap: Record<string, number> = {};
@@ -539,7 +624,10 @@ ${macroContext ? macroContext + "\n" : ""}${reasoningContext ? reasoningContext 
 - Estimated annual dividends: $${report.estimatedAnnualDividend.toFixed(0)}
 
 GAP AMOUNTS (for suggestedBuyValue sizing):
-${report.items.filter(i => i.suggestedBuyValue > 0).map(i => `  ${i.ticker}: $${i.suggestedBuyValue.toFixed(0)} gap`).join("\n")}
+${report.items
+  .filter((i) => i.suggestedBuyValue > 0)
+  .map((i) => `  ${i.ticker}: $${i.suggestedBuyValue.toFixed(0)} gap`)
+  .join("\n")}
 
 STRUCTURED OBSERVATIONS:
 ${obsText}
@@ -581,7 +669,7 @@ async function geminiWithRetry(
   ai: InstanceType<typeof GoogleGenAI>,
   prompt: string,
   schema: Record<string, unknown>,
-  maxRetries: number = 2
+  maxRetries: number = 2,
 ): Promise<string> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -596,10 +684,16 @@ async function geminiWithRetry(
       return response.text ?? "[]";
     } catch (err) {
       const msg = (err as Error).message ?? "";
-      const isRetryable = msg.includes("503") || msg.includes("429") || msg.includes("UNAVAILABLE") || msg.includes("RESOURCE_EXHAUSTED");
+      const isRetryable =
+        msg.includes("503") ||
+        msg.includes("429") ||
+        msg.includes("UNAVAILABLE") ||
+        msg.includes("RESOURCE_EXHAUSTED");
       if (isRetryable && attempt < maxRetries) {
         const delay = (attempt + 1) * 5000; // 5s, 10s
-        console.log(`  ⚠ Gemini ${msg.includes("503") ? "503" : "429"} — retrying in ${delay / 1000}s (attempt ${attempt + 1}/${maxRetries})`);
+        console.log(
+          `  ⚠ Gemini ${msg.includes("503") ? "503" : "429"} — retrying in ${delay / 1000}s (attempt ${attempt + 1}/${maxRetries})`,
+        );
         await new Promise((resolve) => setTimeout(resolve, delay));
         continue;
       }
@@ -616,7 +710,7 @@ export async function aiAnalyze(
   news: Record<string, NewsItem[]>,
   technicals: Record<string, TechnicalData> = {},
   macroContext: string = "",
-  reasoningHistory: ReasoningHistory = { snapshots: {} }
+  reasoningHistory: ReasoningHistory = { snapshots: {} },
 ): Promise<AIBuyRecommendation[]> {
   if (!GEMINI_API_KEY) {
     console.warn("GEMINI_API_KEY not set — skipping AI analysis\n");
@@ -633,9 +727,7 @@ export async function aiAnalyze(
 
     const obsResponse = await geminiWithRetry(ai, obsPrompt, observationSchema);
 
-    const observations = JSON.parse(
-      obsResponse ?? "[]"
-    ) as TickerObservation[];
+    const observations = JSON.parse(obsResponse ?? "[]") as TickerObservation[];
 
     console.log(`  Stage 1 complete — ${observations.length} observations`);
     for (const obs of observations) {
@@ -653,9 +745,15 @@ export async function aiAnalyze(
 
     const decResponse = await geminiWithRetry(ai, decPrompt, responseSchema);
 
-    const recommendations = JSON.parse(
-      decResponse ?? "[]"
-    ) as AIBuyRecommendation[];
+    const recommendations = JSON.parse(decResponse ?? "[]") as AIBuyRecommendation[];
+
+    // Attach tickerFullName from price data (deterministic — not model-supplied)
+    const longNameMap = new Map(
+      Object.values(priceData).map((q) => [q.ticker, q.longName ?? null]),
+    );
+    for (const rec of recommendations) {
+      rec.tickerFullName = longNameMap.get(rec.ticker) ?? null;
+    }
 
     // Run guard validation pipeline (bond ETF cap, earnings proximity, STRONG BUY criteria, etc.)
     validateRecommendations(recommendations, priceData, technicals, report);
@@ -668,7 +766,7 @@ export async function aiAnalyze(
             (rec.valueRating ? ` [${rec.valueRating}]` : "") +
             (rec.bottomSignal ? ` [${rec.bottomSignal}]` : "") +
             ` — ${rec.reason}` +
-            (rec.suggestedLimitPrice ? ` [limit: $${rec.suggestedLimitPrice}]` : "")
+            (rec.suggestedLimitPrice ? ` [limit: $${rec.suggestedLimitPrice}]` : ""),
         );
       }
     }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,13 +1,10 @@
-import {
-  targetPortfolio,
-  currentHoldings,
-  totalPortfolioValueUSD,
-} from "./config.js";
+import { targetPortfolio, currentHoldings, totalPortfolioValueUSD } from "./config.js";
 import type { QuoteData } from "./fetchPrices.js";
 
 // ── Types ───────────────────────────────────────────────────────────
 export interface AllocationItem {
   ticker: string;
+  tickerFullName: string | null;
   currentShares: number;
   currentValue: number;
   currentPct: number;
@@ -34,9 +31,7 @@ export interface AllocationReport {
 }
 
 // ── Analysis ────────────────────────────────────────────────────────
-export function runAnalysis(
-  priceData: Record<string, QuoteData>
-): AllocationReport {
+export function runAnalysis(priceData: Record<string, QuoteData>): AllocationReport {
   // 1. Calculate current value per ticker
   const currentValues: Record<string, number> = {};
   let totalCurrentValue = 0;
@@ -53,10 +48,7 @@ export function runAnalysis(
   const portfolioValue = Math.max(totalCurrentValue, totalPortfolioValueUSD);
 
   // 2. Build allocation items for ALL tickers (target + held)
-  const allTickers = new Set([
-    ...Object.keys(targetPortfolio),
-    ...Object.keys(currentHoldings),
-  ]);
+  const allTickers = new Set([...Object.keys(targetPortfolio), ...Object.keys(currentHoldings)]);
 
   const items: AllocationItem[] = [];
 
@@ -88,19 +80,18 @@ export function runAnalysis(
       overlapDiscount = Math.min(overlapDiscount, suggestedBuyValue);
       suggestedBuyValue -= overlapDiscount;
     }
-    const overlapPct = overlapDiscount > 0 && gapPct > 0
-      ? (overlapDiscount / ((gapPct / 100) * portfolioValue)) * 100
-      : 0;
+    const overlapPct =
+      overlapDiscount > 0 && gapPct > 0
+        ? (overlapDiscount / ((gapPct / 100) * portfolioValue)) * 100
+        : 0;
 
-    const suggestedBuyShares =
-      suggestedBuyValue > 0 ? suggestedBuyValue / quote.price : 0;
+    const suggestedBuyShares = suggestedBuyValue > 0 ? suggestedBuyValue / quote.price : 0;
 
     // P/E signal: compare trailing P/E against dynamic avgPE from Yahoo earnings history
     let peSignal: AllocationItem["peSignal"] = null;
     const benchmark = quote.avgPE ?? null;
     if (quote.trailingPE != null && benchmark != null) {
-      peSignal =
-        quote.trailingPE < benchmark ? "✅ below avg" : "⚠️ above avg";
+      peSignal = quote.trailingPE < benchmark ? "✅ below avg" : "⚠️ above avg";
     }
 
     // 52-week position signal
@@ -117,6 +108,7 @@ export function runAnalysis(
 
     items.push({
       ticker,
+      tickerFullName: quote.longName ?? null,
       currentShares: shares,
       currentValue: value,
       currentPct: Math.round(currentPct * 100) / 100,
@@ -149,9 +141,7 @@ export function runAnalysis(
     }
   }
   const portfolioBeta =
-    weightedBetaTotal > 0
-      ? Math.round((weightedBetaSum / weightedBetaTotal) * 100) / 100
-      : null;
+    weightedBetaTotal > 0 ? Math.round((weightedBetaSum / weightedBetaTotal) * 100) / 100 : null;
 
   // 4. Estimated annual dividend income
   let estimatedAnnualDividend = 0;

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ try {
   raw = readFileSync(configPath, "utf-8");
 } catch {
   throw new Error(
-    `Missing config.json — copy config.example.json to config.json and edit it:\n  cp config.example.json config.json`
+    `Missing config.json — copy config.example.json to config.json and edit it:\n  cp config.example.json config.json`,
   );
 }
 
@@ -50,8 +50,7 @@ export const intradayConfig: IntradayAlertConfig = {
 };
 
 // ── Environment-only settings ───────────────────────────────────────
-export const recipientEmail =
-  process.env.RECIPIENT_EMAIL || "you@example.com";
+export const recipientEmail = process.env.RECIPIENT_EMAIL || "you@example.com";
 
 // ── Ticker mapping ──────────────────────────────────────────────────
 // Yahoo Finance requires specific ticker formats for crypto
@@ -75,10 +74,5 @@ export function fromYahooTicker(yahooTicker: string): string {
 
 /** Get all unique tickers from both target and current holdings */
 export function allUniqueTickers(): string[] {
-  return [
-    ...new Set([
-      ...Object.keys(targetPortfolio),
-      ...Object.keys(currentHoldings),
-    ]),
-  ];
+  return [...new Set([...Object.keys(targetPortfolio), ...Object.keys(currentHoldings)])];
 }

--- a/src/detailedAnalysis.ts
+++ b/src/detailedAnalysis.ts
@@ -38,7 +38,7 @@ function buildDetailedPrompt(
   tech: TechnicalData | undefined,
   rec: AIBuyRecommendation,
   report: AllocationReport,
-  macroContext: string = ""
+  macroContext: string = "",
 ): string {
   const item = report.items.find((i) => i.ticker === ticker);
   const gap = item ? `${item.gapPct > 0 ? "+" : ""}${item.gapPct.toFixed(1)}%` : "N/A";
@@ -48,22 +48,28 @@ function buildDetailedPrompt(
   const lines = [
     `You are a senior investment analyst writing a detailed buy recommendation for a client.`,
     ``,
-    `TICKER: ${ticker}`,
+    `TICKER: ${ticker}${quote.longName ? ` (${quote.longName})` : ""}`,
     `Current price: $${quote.price.toFixed(2)}`,
     `Trailing P/E: ${quote.trailingPE?.toFixed(1) ?? "N/A"} | Forward P/E: ${quote.forwardPE?.toFixed(1) ?? "N/A"} | Avg P/E: ${quote.avgPE?.toFixed(1) ?? "N/A"}`,
     (() => {
-      const wpPct = quote.fiftyTwoWeekPercent != null ? Math.round(quote.fiftyTwoWeekPercent * 100) : null;
-      const belowHigh = quote.fiftyTwoWeekHigh != null
-        ? ((quote.fiftyTwoWeekHigh - quote.price) / quote.fiftyTwoWeekHigh * 100).toFixed(1)
-        : null;
-      const aboveLow = quote.fiftyTwoWeekLow != null
-        ? ((quote.price - quote.fiftyTwoWeekLow) / quote.fiftyTwoWeekLow * 100).toFixed(1)
-        : null;
-      if (wpPct == null) return `52-week: low $${quote.fiftyTwoWeekLow?.toFixed(2) ?? "N/A"} — high $${quote.fiftyTwoWeekHigh?.toFixed(2) ?? "N/A"} (position N/A)`;
+      const wpPct =
+        quote.fiftyTwoWeekPercent != null ? Math.round(quote.fiftyTwoWeekPercent * 100) : null;
+      const belowHigh =
+        quote.fiftyTwoWeekHigh != null
+          ? (((quote.fiftyTwoWeekHigh - quote.price) / quote.fiftyTwoWeekHigh) * 100).toFixed(1)
+          : null;
+      const aboveLow =
+        quote.fiftyTwoWeekLow != null
+          ? (((quote.price - quote.fiftyTwoWeekLow) / quote.fiftyTwoWeekLow) * 100).toFixed(1)
+          : null;
+      if (wpPct == null)
+        return `52-week: low $${quote.fiftyTwoWeekLow?.toFixed(2) ?? "N/A"} — high $${quote.fiftyTwoWeekHigh?.toFixed(2) ?? "N/A"} (position N/A)`;
       const qualifier = wpPct < 20 ? " ← NEAR ANNUAL LOW" : wpPct > 70 ? " ← NEAR ANNUAL HIGH" : "";
-      return `52-week: low $${quote.fiftyTwoWeekLow?.toFixed(2)} — high $${quote.fiftyTwoWeekHigh?.toFixed(2)} | ${wpPct}% of range (0%=at low, 100%=at high)${qualifier}` +
+      return (
+        `52-week: low $${quote.fiftyTwoWeekLow?.toFixed(2)} — high $${quote.fiftyTwoWeekHigh?.toFixed(2)} | ${wpPct}% of range (0%=at low, 100%=at high)${qualifier}` +
         (belowHigh != null ? ` | ${belowHigh}% below 52w high` : "") +
-        (aboveLow != null ? ` | ${aboveLow}% above 52w low` : "");
+        (aboveLow != null ? ` | ${aboveLow}% above 52w low` : "")
+      );
     })(),
     `Dividend yield: ${quote.dividendYield != null ? (quote.dividendYield * 100).toFixed(2) + "%" : "N/A"} | Beta: ${quote.beta?.toFixed(2) ?? "N/A"}`,
     `Allocation: current ${current}, target ${target}, gap ${gap}`,
@@ -71,13 +77,16 @@ function buildDetailedPrompt(
   ];
 
   if (tech) {
-    const priceBelow200 = tech.sma200 != null && tech.priceVsSma200 != null && tech.priceVsSma200 < 0;
+    const priceBelow200 =
+      tech.sma200 != null && tech.priceVsSma200 != null && tech.priceVsSma200 < 0;
     const goldenCrossNote = tech.goldenCross
       ? priceBelow200
         ? " (golden cross — BUT price is below 200MA, so this is a lagging artifact, NOT a bullish signal)"
         : " (golden cross)"
       : "";
-    lines.push(`Technical: ${tech.momentumSignal} momentum, RSI ${tech.rsi14}, 50MA $${tech.sma50} (${tech.priceVsSma50 > 0 ? "+" : ""}${tech.priceVsSma50}%)${tech.sma200 != null ? `, 200MA $${tech.sma200} (${tech.priceVsSma200! > 0 ? "+" : ""}${tech.priceVsSma200}%)` : ""}${goldenCrossNote}${tech.deathCross ? " (death cross)" : ""}${tech.macdCrossover ? `, MACD ${tech.macdCrossover}` : tech.macdHistogram != null ? `, MACD hist ${tech.macdHistogram > 0 ? "+" : ""}${tech.macdHistogram}` : ""}${tech.bollPercentB != null ? `, %B=${tech.bollPercentB}` : ""}${tech.bollSqueeze ? " (squeeze)" : ""}`);
+    lines.push(
+      `Technical: ${tech.momentumSignal} momentum, RSI ${tech.rsi14}, 50MA $${tech.sma50} (${tech.priceVsSma50 > 0 ? "+" : ""}${tech.priceVsSma50}%)${tech.sma200 != null ? `, 200MA $${tech.sma200} (${tech.priceVsSma200! > 0 ? "+" : ""}${tech.priceVsSma200}%)` : ""}${goldenCrossNote}${tech.deathCross ? " (death cross)" : ""}${tech.macdCrossover ? `, MACD ${tech.macdCrossover}` : tech.macdHistogram != null ? `, MACD hist ${tech.macdHistogram > 0 ? "+" : ""}${tech.macdHistogram}` : ""}${tech.bollPercentB != null ? `, %B=${tech.bollPercentB}` : ""}${tech.bollSqueeze ? " (squeeze)" : ""}`,
+    );
   }
 
   if (quote.returnOnEquity != null || quote.debtToEquity != null) {
@@ -86,7 +95,9 @@ function buildDetailedPrompt(
       quote.debtToEquity != null ? `D/E ${quote.debtToEquity.toFixed(1)}%` : null,
       quote.profitMargins != null ? `margin ${(quote.profitMargins * 100).toFixed(1)}%` : null,
       quote.revenueGrowth != null ? `rev growth ${(quote.revenueGrowth * 100).toFixed(1)}%` : null,
-      quote.earningsGrowth != null ? `earnings growth ${(quote.earningsGrowth * 100).toFixed(1)}%` : null,
+      quote.earningsGrowth != null
+        ? `earnings growth ${(quote.earningsGrowth * 100).toFixed(1)}%`
+        : null,
       quote.targetMeanPrice != null ? `analyst target $${quote.targetMeanPrice.toFixed(2)}` : null,
     ].filter(Boolean);
     lines.push(`Fundamentals: ${fundamentals.join(", ")}`);
@@ -112,8 +123,15 @@ function buildDetailedPrompt(
   lines.push("4. Portfolio fit (allocation need, diversification benefit)");
   lines.push("");
   lines.push("CRITICAL RULES:");
-  lines.push("- The 52-week position percentage is the position WITHIN the annual range (0%=at 52w low, 100%=at 52w high). Do NOT describe it as '% of 52-week high' — that is a different number. Use the explicit '% below 52w high' value provided.");
-  lines.push("- If price is below the 200-day MA, do NOT cite a golden cross as bullish — it is a lagging artifact when price has already fallen below the long-term trend.");
+  lines.push(
+    '- Use the full company/ETF name shown next to the ticker above (when available) in your thesis, not generic phrases like "this stock" or "this ETF".',
+  );
+  lines.push(
+    "- The 52-week position percentage is the position WITHIN the annual range (0%=at 52w low, 100%=at 52w high). Do NOT describe it as '% of 52-week high' — that is a different number. Use the explicit '% below 52w high' value provided.",
+  );
+  lines.push(
+    "- If price is below the 200-day MA, do NOT cite a golden cross as bullish — it is a lagging artifact when price has already fallen below the long-term trend.",
+  );
   lines.push("");
   lines.push("Also list 3-4 specific risks to watch. Be concise and reference actual numbers.");
 
@@ -127,7 +145,7 @@ export async function fetchDetailedAnalyses(
   technicals: Record<string, TechnicalData>,
   aiRecs: AIBuyRecommendation[],
   report: AllocationReport,
-  macroContext: string = ""
+  macroContext: string = "",
 ): Promise<Record<string, DetailedAnalysis>> {
   if (!GEMINI_API_KEY || strongBuyTickers.length === 0) return {};
 
@@ -143,7 +161,14 @@ export async function fetchDetailedAnalyses(
     if (!quote || !rec) continue;
 
     try {
-      const prompt = buildDetailedPrompt(ticker, quote, technicals[ticker], rec, report, macroContext);
+      const prompt = buildDetailedPrompt(
+        ticker,
+        quote,
+        technicals[ticker],
+        rec,
+        report,
+        macroContext,
+      );
 
       const response = await ai.models.generateContent({
         model: "gemini-2.5-flash",

--- a/src/email.ts
+++ b/src/email.ts
@@ -5,6 +5,7 @@ import type { AIBuyRecommendation } from "./aiAnalysis.js";
 import type { NewsItem } from "./fetchNews.js";
 import type { TechnicalData } from "./fetchTechnicals.js";
 import type { QuoteData } from "./fetchPrices.js";
+import { escapeHtmlAttr } from "./util.js";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -65,13 +66,20 @@ function actionBadge(action: string): string {
 
 function confidenceBar(pct: number): string {
   const color = pct >= 70 ? S.green : pct >= 40 ? S.yellow : S.red;
-  return `<div style="display:inline-block;width:60px;height:8px;background:${S.border};border-radius:4px;vertical-align:middle;">` +
+  return (
+    `<div style="display:inline-block;width:60px;height:8px;background:${S.border};border-radius:4px;vertical-align:middle;">` +
     `<div style="width:${pct}%;height:100%;background:${color};border-radius:4px;"></div>` +
-    `</div> <span style="font-size:11px;color:${S.muted};">${pct}%</span>`;
+    `</div> <span style="font-size:11px;color:${S.muted};">${pct}%</span>`
+  );
 }
 
 // ── Value rating color ───────────────────────────────────────────────
-const ratingColors: Record<string, string> = { A: "#2ecc71", B: "#3498db", C: "#f39c12", D: "#e74c3c" };
+const ratingColors: Record<string, string> = {
+  A: "#2ecc71",
+  B: "#3498db",
+  C: "#f39c12",
+  D: "#e74c3c",
+};
 
 function valueRatingBadge(rating: string | undefined): string {
   if (!rating || rating === "") return "";
@@ -87,7 +95,8 @@ function earningsBadge(daysToEarnings: number | null): string {
 
 // ── Technical Insight (STRONG BUY + BUY with extras) ────────────────
 function buildTechnicalInsight(rec: AIBuyRecommendation, tech: TechnicalData | undefined): string {
-  const hasExtras = (rec.valueRating && rec.valueRating !== "") || (rec.bottomSignal && rec.bottomSignal !== "");
+  const hasExtras =
+    (rec.valueRating && rec.valueRating !== "") || (rec.bottomSignal && rec.bottomSignal !== "");
   if (rec.action !== "STRONG BUY" && !hasExtras) return "";
   if (!tech && !hasExtras) return "";
 
@@ -95,7 +104,12 @@ function buildTechnicalInsight(rec: AIBuyRecommendation, tech: TechnicalData | u
 
   // Technical momentum line (STRONG BUY only)
   if (rec.action === "STRONG BUY" && tech) {
-    const momentumColor = tech.momentumSignal === "bullish" ? S.green : tech.momentumSignal === "bearish" ? S.red : S.muted;
+    const momentumColor =
+      tech.momentumSignal === "bullish"
+        ? S.green
+        : tech.momentumSignal === "bearish"
+          ? S.red
+          : S.muted;
     const rsiColor = tech.rsi14 < 30 ? S.green : tech.rsi14 > 70 ? S.red : S.muted;
 
     const lines = [
@@ -113,7 +127,9 @@ function buildTechnicalInsight(rec: AIBuyRecommendation, tech: TechnicalData | u
       lines.push(`MACD <span style="color:${macdColor};">${tech.macdCrossover}</span>`);
     } else if (tech.macdHistogram != null) {
       const histColor = tech.macdHistogram > 0 ? S.green : S.red;
-      lines.push(`MACD hist <span style="color:${histColor};">${tech.macdHistogram > 0 ? "+" : ""}${tech.macdHistogram}</span>`);
+      lines.push(
+        `MACD hist <span style="color:${histColor};">${tech.macdHistogram > 0 ? "+" : ""}${tech.macdHistogram}</span>`,
+      );
     }
     if (tech.bollPercentB != null) {
       const bColor = tech.bollPercentB < 0.2 ? S.green : tech.bollPercentB > 0.8 ? S.red : S.muted;
@@ -142,13 +158,13 @@ function buildTechnicalInsight(rec: AIBuyRecommendation, tech: TechnicalData | u
 }
 
 // ── AI Recommendations Section ──────────────────────────────────────
-function buildAISection(aiRecs: AIBuyRecommendation[], technicals: Record<string, TechnicalData> = {}, priceData: Record<string, QuoteData> = {}): string {
-  const actionable = aiRecs.filter(
-    (r) => r.action === "STRONG BUY" || r.action === "BUY"
-  );
-  const others = aiRecs.filter(
-    (r) => r.action !== "STRONG BUY" && r.action !== "BUY"
-  );
+function buildAISection(
+  aiRecs: AIBuyRecommendation[],
+  technicals: Record<string, TechnicalData> = {},
+  priceData: Record<string, QuoteData> = {},
+): string {
+  const actionable = aiRecs.filter((r) => r.action === "STRONG BUY" || r.action === "BUY");
+  const others = aiRecs.filter((r) => r.action !== "STRONG BUY" && r.action !== "BUY");
 
   return `
 <tr><td style="padding:20px 24px 8px;background:${S.cardBg};">
@@ -156,31 +172,51 @@ function buildAISection(aiRecs: AIBuyRecommendation[], technicals: Record<string
   <p style="margin:4px 0 0;font-size:11px;color:${S.muted};">Powered by Gemini — considers fundamentals, valuation, allocation gap, technicals, and news sentiment.</p>
 </td></tr>
 <tr><td style="padding:0 24px 16px;background:${S.cardBg};">
-  ${actionable.length > 0 ? actionable.map((rec) => `
+  ${
+    actionable.length > 0
+      ? actionable
+          .map(
+            (rec) => `
   <div style="padding:10px 0;border-bottom:1px solid ${S.border};">
     <div style="margin-bottom:4px;">
-      <span style="font-weight:bold;font-size:14px;color:#fff;">${rec.ticker}</span>
+      <span style="font-weight:bold;font-size:14px;color:#fff;" title="${escapeHtmlAttr(rec.tickerFullName ?? rec.ticker)}">${rec.ticker}</span>
       &nbsp;${actionBadge(rec.action)}${valueRatingBadge(rec.valueRating)}${earningsBadge(priceData[rec.ticker]?.daysToEarnings ?? null)}
       &nbsp;${confidenceBar(rec.confidence)}
       ${rec.suggestedBuyValue > 0 ? `<span style="float:right;font-weight:bold;color:#fff;">${fmt$(rec.suggestedBuyValue)}</span>` : ""}
     </div>
     <div style="font-size:12px;color:${S.text};margin-top:4px;">${rec.reason}</div>
     ${buildTechnicalInsight(rec, technicals[rec.ticker])}
-    ${rec.action === "STRONG BUY" && rec.analysisUrl ? `
+    ${
+      rec.action === "STRONG BUY" && rec.analysisUrl
+        ? `
     <div style="margin-top:8px;">
       <a href="${rec.analysisUrl}" style="display:inline-block;background:${S.blue}22;color:${S.blue};padding:4px 12px;border-radius:4px;font-size:11px;font-weight:bold;text-decoration:none;border:1px solid ${S.blue}44;">More Details &rarr;</a>
-    </div>` : ""}
-  </div>`).join("") : `<p style="color:${S.muted};font-size:13px;">No strong buy opportunities identified today.</p>`}
-  ${others.length > 0 ? `
+    </div>`
+        : ""
+    }
+  </div>`,
+          )
+          .join("")
+      : `<p style="color:${S.muted};font-size:13px;">No strong buy opportunities identified today.</p>`
+  }
+  ${
+    others.length > 0
+      ? `
   <div style="margin-top:12px;">
     <div style="font-size:11px;color:${S.muted};text-transform:uppercase;margin-bottom:6px;">Hold / Wait</div>
-    ${others.map((rec) => `
+    ${others
+      .map(
+        (rec) => `
     <div style="padding:4px 0;font-size:12px;">
-      <span style="font-weight:bold;">${rec.ticker}</span>
+      <span style="font-weight:bold;" title="${escapeHtmlAttr(rec.tickerFullName ?? rec.ticker)}">${rec.ticker}</span>
       &nbsp;${actionBadge(rec.action)}${valueRatingBadge(rec.valueRating)}
       <span style="color:${S.muted};margin-left:8px;">${rec.reason}</span>
-    </div>`).join("")}
-  </div>` : ""}
+    </div>`,
+      )
+      .join("")}
+  </div>`
+      : ""
+  }
 </td></tr>`;
 }
 
@@ -204,15 +240,19 @@ function buildFallbackBuysSection(report: AllocationReport): string {
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:center;">P/E</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:center;">52w</td>
     </tr>
-    ${buys.map((b) => `
+    ${buys
+      .map(
+        (b) => `
     <tr>
-      <td style="padding:6px 4px;border-bottom:1px solid ${S.border};font-weight:bold;">${b.ticker}</td>
+      <td style="padding:6px 4px;border-bottom:1px solid ${S.border};font-weight:bold;" title="${escapeHtmlAttr(b.tickerFullName ?? b.ticker)}">${b.ticker}</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:right;color:${S.red};">${fmtPct(b.gapPct)}</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:right;">${b.suggestedBuyShares.toFixed(1)}</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:right;">${fmt$(b.suggestedBuyValue)}${b.overlapDiscount > 0 ? `<div style="font-size:10px;color:${S.muted};">-${fmt$(b.overlapDiscount)} overlap</div>` : ""}</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:center;">${fmtPE(b)}</td>
       <td style="padding:6px 4px;border-bottom:1px solid ${S.border};text-align:center;">${b.weekSignal ?? "—"}</td>
-    </tr>`).join("")}
+    </tr>`,
+      )
+      .join("")}
   </table>
 </td></tr>`;
 }
@@ -223,7 +263,7 @@ export function buildEmailHtml(
   news: Record<string, NewsItem[]>,
   aiRecs: AIBuyRecommendation[] = [],
   technicals: Record<string, TechnicalData> = {},
-  priceData: Record<string, QuoteData> = {}
+  priceData: Record<string, QuoteData> = {},
 ): string {
   const date = new Date().toLocaleDateString("en-AU", {
     weekday: "long",
@@ -235,9 +275,10 @@ export function buildEmailHtml(
   const tickersWithNews = Object.entries(news).filter(([, items]) => items.length > 0);
 
   // Use AI section if available, otherwise fallback to gap-based
-  const buysSection = aiRecs.length > 0
-    ? buildAISection(aiRecs, technicals, priceData)
-    : buildFallbackBuysSection(report);
+  const buysSection =
+    aiRecs.length > 0
+      ? buildAISection(aiRecs, technicals, priceData)
+      : buildFallbackBuysSection(report);
 
   return `<!DOCTYPE html>
 <html>
@@ -289,9 +330,11 @@ ${buysSection}
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">Beta</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};">52w Range</td>
     </tr>
-    ${report.items.map((item) => `
+    ${report.items
+      .map(
+        (item) => `
     <tr>
-      <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-weight:bold;">${item.ticker}</td>
+      <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-weight:bold;" title="${escapeHtmlAttr(item.tickerFullName ?? item.ticker)}">${item.ticker}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">$${item.price.toLocaleString("en-US", { maximumFractionDigits: 2 })}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">${item.currentPct.toFixed(1)}%</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">${item.targetPct.toFixed(1)}%</td>
@@ -300,27 +343,41 @@ ${buysSection}
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">${item.dividendYield != null ? (item.dividendYield * 100).toFixed(1) + "%" : "—"}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">${item.beta?.toFixed(2) ?? "—"}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-family:monospace;font-size:11px;">${weekBar(item.fiftyTwoWeekPercent)}</td>
-    </tr>`).join("")}
+    </tr>`,
+      )
+      .join("")}
   </table>
 </td></tr>
 
 <!-- News Digest -->
-${tickersWithNews.length > 0 ? `
+${
+  tickersWithNews.length > 0
+    ? `
 <tr><td style="padding:20px 24px 8px;background:${S.cardBg};border-top:1px solid ${S.border};">
   <h2 style="margin:0;font-size:16px;color:${S.blue};">News Digest</h2>
 </td></tr>
 <tr><td style="padding:0 24px 16px;background:${S.cardBg};">
-  ${tickersWithNews.map(([ticker, articles]) => `
+  ${tickersWithNews
+    .map(
+      ([ticker, articles]) => `
   <div style="margin-bottom:12px;">
     <div style="font-weight:bold;font-size:13px;color:#fff;margin-bottom:4px;">${ticker}</div>
-    ${articles.map((a) => `
+    ${articles
+      .map(
+        (a) => `
     <div style="margin-left:12px;margin-bottom:4px;font-size:12px;">
       <a href="${a.url}" style="color:${S.blue};text-decoration:none;">→ ${a.title}</a>
       <span style="color:${S.muted};font-size:11px;"> — ${a.source}</span>
-    </div>`).join("")}
-  </div>`).join("")}
+    </div>`,
+      )
+      .join("")}
+  </div>`,
+    )
+    .join("")}
 </td></tr>
-` : ""}
+`
+    : ""
+}
 
 <!-- Footer -->
 <tr><td style="padding:16px 24px;background:${S.accent};border-radius:0 0 8px 8px;text-align:center;">
@@ -340,7 +397,7 @@ export async function sendBrief(
   news: Record<string, NewsItem[]>,
   aiRecs: AIBuyRecommendation[] = [],
   technicals: Record<string, TechnicalData> = {},
-  priceData: Record<string, QuoteData> = {}
+  priceData: Record<string, QuoteData> = {},
 ): Promise<void> {
   const html = buildEmailHtml(report, news, aiRecs, technicals, priceData);
 

--- a/src/fetchNews.ts
+++ b/src/fetchNews.ts
@@ -33,7 +33,10 @@ function getSearchNames(ticker: string, priceData: Record<string, QuoteData>): s
   const quote = priceData[ticker];
   if (quote?.name) {
     const cleaned = quote.name
-      .replace(/,?\s*(Inc\.?|Corp\.?|Ltd\.?|PLC|S\.?A\.?|N\.?V\.?|SE|plc|Holdings?|Group|Co\.?)$/i, "")
+      .replace(
+        /,?\s*(Inc\.?|Corp\.?|Ltd\.?|PLC|S\.?A\.?|N\.?V\.?|SE|plc|Holdings?|Group|Co\.?)$/i,
+        "",
+      )
       .trim();
     if (cleaned.length > 1) return [cleaned];
   }
@@ -70,7 +73,7 @@ interface NewsApiResponse {
 // ── Fetch a batch of tickers ────────────────────────────────────────
 async function fetchBatch(
   tickers: string[],
-  priceData: Record<string, QuoteData>
+  priceData: Record<string, QuoteData>,
 ): Promise<Record<string, NewsItem[]>> {
   // Build query using ticker symbols + company names for better coverage
   const queryTerms: string[] = [];
@@ -81,9 +84,7 @@ async function fetchBatch(
   }
   const query = queryTerms.join(" OR ");
 
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000)
-    .toISOString()
-    .slice(0, 10);
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
   const params = new URLSearchParams({
     q: query,
@@ -167,7 +168,7 @@ const relevanceSchema = {
 };
 
 async function filterNewsWithGemini(
-  allNews: Record<string, NewsItem[]>
+  allNews: Record<string, NewsItem[]>,
 ): Promise<Record<string, NewsItem[]>> {
   if (!GEMINI_API_KEY) return allNews;
 
@@ -220,10 +221,13 @@ If no headlines are relevant, return an empty articles array and "neutral" for o
         break;
       } catch (retryErr) {
         const msg = (retryErr as Error).message ?? "";
-        const isRetryable = msg.includes("503") || msg.includes("429") || msg.includes("UNAVAILABLE");
+        const isRetryable =
+          msg.includes("503") || msg.includes("429") || msg.includes("UNAVAILABLE");
         if (isRetryable && attempt < 2) {
           const delay = (attempt + 1) * 5000;
-          console.log(`  ⚠ Gemini news filter ${msg.includes("503") ? "503" : "429"} — retrying in ${delay / 1000}s`);
+          console.log(
+            `  ⚠ Gemini news filter ${msg.includes("503") ? "503" : "429"} — retrying in ${delay / 1000}s`,
+          );
           await new Promise((resolve) => setTimeout(resolve, delay));
           continue;
         }
@@ -252,8 +256,12 @@ If no headlines are relevant, return an empty articles array and "neutral" for o
         .filter((a) => a.index >= 0 && a.index < original.length)
         .map((a) => ({
           ...original[a.index],
-          sentiment: (["bullish", "bearish", "neutral"].includes(a.sentiment) ? a.sentiment : "neutral") as NewsItem["sentiment"],
-          impact: (["high", "medium", "low"].includes(a.impact) ? a.impact : "medium") as NewsItem["impact"],
+          sentiment: (["bullish", "bearish", "neutral"].includes(a.sentiment)
+            ? a.sentiment
+            : "neutral") as NewsItem["sentiment"],
+          impact: (["high", "medium", "low"].includes(a.impact)
+            ? a.impact
+            : "medium") as NewsItem["impact"],
         }));
       sentimentMap[entry.ticker] = (
         ["bullish", "bearish", "neutral", "mixed"].includes(entry.overallSentiment)
@@ -267,12 +275,16 @@ If no headlines are relevant, return an empty articles array and "neutral" for o
     const before = Object.values(allNews).reduce((s, a) => s + a.length, 0);
     const after = Object.values(result).reduce((s, a) => s + a.length, 0);
     if (before !== after) {
-      console.log(`  Gemini filter: ${before} → ${after} articles (removed ${before - after} irrelevant)`);
+      console.log(
+        `  Gemini filter: ${before} → ${after} articles (removed ${before - after} irrelevant)`,
+      );
     }
 
     return result;
   } catch (err) {
-    console.warn(`  ⚠ Gemini news filter failed, using unfiltered results: ${(err as Error).message}`);
+    console.warn(
+      `  ⚠ Gemini news filter failed, using unfiltered results: ${(err as Error).message}`,
+    );
     return allNews;
   }
 }
@@ -286,7 +298,7 @@ export function getNewsSentiment(): Record<string, TickerSentiment> {
 // ── Fetch news for all tickers ──────────────────────────────────────
 export async function fetchNews(
   tickers: string[],
-  priceData: Record<string, QuoteData> = {}
+  priceData: Record<string, QuoteData> = {},
 ): Promise<Record<string, NewsItem[]>> {
   if (!NEWS_API_KEY) {
     console.warn("NEWS_API_KEY not set — skipping news fetch\n");
@@ -303,10 +315,7 @@ export async function fetchNews(
       const batchNews = await fetchBatch(batch, priceData);
       Object.assign(allNews, batchNews);
     } catch (err) {
-      console.error(
-        `  ✗ News batch [${batch.join(", ")}] failed:`,
-        (err as Error).message
-      );
+      console.error(`  ✗ News batch [${batch.join(", ")}] failed:`, (err as Error).message);
       for (const t of batch) allNews[t] = [];
     }
   }

--- a/src/fetchPrices.ts
+++ b/src/fetchPrices.ts
@@ -3,7 +3,7 @@ import { toYahooTicker, fromYahooTicker } from "./config.js";
 
 const yahooFinance = new YahooFinance({
   suppressNotices: ["yahooSurvey"],
-  validation: { logErrors: false },  // Don't throw on schema validation errors (e.g. BIPC missing earningsHistory fields)
+  validation: { logErrors: false }, // Don't throw on schema validation errors (e.g. BIPC missing earningsHistory fields)
 });
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -15,6 +15,7 @@ export interface HoldingInfo {
 export interface QuoteData {
   ticker: string;
   name: string | null;
+  longName: string | null;
   price: number;
   trailingPE: number | null;
   forwardPE: number | null;
@@ -61,11 +62,18 @@ async function fetchOne(yahooTicker: string): Promise<QuoteData | null> {
 
   try {
     const result = await yahooFinance.quoteSummary(yahooTicker, {
-      modules: ["price", "summaryDetail", "defaultKeyStatistics", "earningsHistory", "topHoldings", "financialData", "calendarEvents"],
+      modules: [
+        "price",
+        "summaryDetail",
+        "defaultKeyStatistics",
+        "earningsHistory",
+        "topHoldings",
+        "financialData",
+        "calendarEvents",
+      ],
     });
 
-    const price =
-      result.price?.regularMarketPrice ?? null;
+    const price = result.price?.regularMarketPrice ?? null;
 
     if (price == null) {
       console.warn(`  ⚠ ${configTicker}: no price data, skipping`);
@@ -74,9 +82,7 @@ async function fetchOne(yahooTicker: string): Promise<QuoteData | null> {
 
     const high = result.summaryDetail?.fiftyTwoWeekHigh ?? null;
     const low = result.summaryDetail?.fiftyTwoWeekLow ?? null;
-    const range = high != null && low != null && high !== low
-      ? (price - low) / (high - low)
-      : null;
+    const range = high != null && low != null && high !== low ? (price - low) / (high - low) : null;
 
     // Compute avg P/E from earnings history (quarterly EPS)
     let avgPE: number | null = null;
@@ -86,8 +92,7 @@ async function fetchOne(yahooTicker: string): Promise<QuoteData | null> {
         .map((q) => q.epsActual)
         .filter((eps): eps is number => eps != null && eps > 0);
       if (epsValues.length >= 2) {
-        const avgQuarterlyEPS =
-          epsValues.reduce((sum, eps) => sum + eps, 0) / epsValues.length;
+        const avgQuarterlyEPS = epsValues.reduce((sum, eps) => sum + eps, 0) / epsValues.length;
         const annualizedEPS = avgQuarterlyEPS * 4;
         if (annualizedEPS > 0) {
           avgPE = Math.round((price / annualizedEPS) * 10) / 10;
@@ -110,6 +115,7 @@ async function fetchOne(yahooTicker: string): Promise<QuoteData | null> {
     return {
       ticker: configTicker,
       name: result.price?.shortName ?? result.price?.longName ?? null,
+      longName: result.price?.longName ?? result.price?.shortName ?? null,
       price,
       trailingPE: result.summaryDetail?.trailingPE ?? null,
       forwardPE: result.summaryDetail?.forwardPE ?? null,
@@ -154,13 +160,13 @@ async function fetchOne(yahooTicker: string): Promise<QuoteData | null> {
 
 // ── Macro indicators ───────────────────────────────────────────────
 export interface MacroIndicators {
-  vix: number | null;          // ^VIX — fear index
-  treasury10y: number | null;  // ^TNX — 10-year yield (%)
-  sp500Price: number | null;   // ^GSPC — S&P 500 level
-  sp500YtdPct: number | null;  // S&P 500 YTD return (%)
-  sp50052wPct: number | null;  // S&P 500 52-week position (0-1)
-  oilPrice: number | null;     // CL=F — WTI crude
-  dxy: number | null;          // DX-Y.NYB — USD index
+  vix: number | null; // ^VIX — fear index
+  treasury10y: number | null; // ^TNX — 10-year yield (%)
+  sp500Price: number | null; // ^GSPC — S&P 500 level
+  sp500YtdPct: number | null; // S&P 500 YTD return (%)
+  sp50052wPct: number | null; // S&P 500 52-week position (0-1)
+  oilPrice: number | null; // CL=F — WTI crude
+  dxy: number | null; // DX-Y.NYB — USD index
 }
 
 const MACRO_TICKERS: Record<string, string> = {
@@ -211,7 +217,9 @@ export async function fetchMacroIndicators(): Promise<MacroIndicators> {
           if (high != null) {
             indicators.sp500YtdPct = Math.round(((price - high) / high) * 1000) / 10;
           }
-          console.log(`  ✓ S&P 500: ${indicators.sp500Price}${indicators.sp50052wPct != null ? ` (52w: ${Math.round(indicators.sp50052wPct * 100)}%)` : ""}`);
+          console.log(
+            `  ✓ S&P 500: ${indicators.sp500Price}${indicators.sp50052wPct != null ? ` (52w: ${Math.round(indicators.sp50052wPct * 100)}%)` : ""}`,
+          );
           break;
         }
         case "oil":
@@ -236,16 +244,31 @@ export function formatMacroContext(m: MacroIndicators): string {
   const lines: string[] = ["MACRO ENVIRONMENT:"];
 
   if (m.vix != null) {
-    const level = m.vix >= 30 ? "high fear" : m.vix >= 20 ? "elevated" : m.vix >= 15 ? "moderate" : "low/complacent";
+    const level =
+      m.vix >= 30
+        ? "high fear"
+        : m.vix >= 20
+          ? "elevated"
+          : m.vix >= 15
+            ? "moderate"
+            : "low/complacent";
     lines.push(`- VIX: ${m.vix} (${level} — >30 = crisis-level fear, <15 = complacent)`);
   }
   if (m.treasury10y != null) {
-    const level = m.treasury10y >= 5 ? "very high — significant headwind for equities" : m.treasury10y >= 4 ? "elevated — pressures equity valuations" : m.treasury10y >= 3 ? "moderate" : "low — supportive for equities";
+    const level =
+      m.treasury10y >= 5
+        ? "very high — significant headwind for equities"
+        : m.treasury10y >= 4
+          ? "elevated — pressures equity valuations"
+          : m.treasury10y >= 3
+            ? "moderate"
+            : "low — supportive for equities";
     lines.push(`- 10-Year Treasury yield: ${m.treasury10y}% (${level})`);
   }
   if (m.sp500Price != null) {
     let sp500Line = `- S&P 500: ${m.sp500Price.toLocaleString()}`;
-    if (m.sp500YtdPct != null) sp500Line += ` (${m.sp500YtdPct > 0 ? "+" : ""}${m.sp500YtdPct}% from 52w high)`;
+    if (m.sp500YtdPct != null)
+      sp500Line += ` (${m.sp500YtdPct > 0 ? "+" : ""}${m.sp500YtdPct}% from 52w high)`;
     if (m.sp50052wPct != null) {
       const pct = Math.round(m.sp50052wPct * 100);
       sp500Line += ` | 52w position: ${pct}%`;
@@ -253,24 +276,38 @@ export function formatMacroContext(m: MacroIndicators): string {
     lines.push(sp500Line);
   }
   if (m.oilPrice != null) {
-    const level = m.oilPrice >= 100 ? "very high — inflation risk" : m.oilPrice >= 80 ? "elevated" : m.oilPrice >= 60 ? "moderate" : "low — deflationary signal";
+    const level =
+      m.oilPrice >= 100
+        ? "very high — inflation risk"
+        : m.oilPrice >= 80
+          ? "elevated"
+          : m.oilPrice >= 60
+            ? "moderate"
+            : "low — deflationary signal";
     lines.push(`- Oil (WTI): $${m.oilPrice} (${level})`);
   }
   if (m.dxy != null) {
-    const level = m.dxy >= 108 ? "very strong — headwind for multinationals" : m.dxy >= 103 ? "strong" : m.dxy >= 97 ? "neutral" : "weak — tailwind for multinationals";
+    const level =
+      m.dxy >= 108
+        ? "very strong — headwind for multinationals"
+        : m.dxy >= 103
+          ? "strong"
+          : m.dxy >= 97
+            ? "neutral"
+            : "weak — tailwind for multinationals";
     lines.push(`- USD Index (DXY): ${m.dxy} (${level})`);
   }
 
   if (lines.length === 1) return ""; // No data fetched
   lines.push("");
-  lines.push("Use this macro context to inform risk assessment and confidence levels. Elevated VIX + high yields + strong USD = defensive posture. Low VIX + low yields = risk-on environment.");
+  lines.push(
+    "Use this macro context to inform risk assessment and confidence levels. Elevated VIX + high yields + strong USD = defensive posture. Low VIX + low yields = risk-on environment.",
+  );
   return lines.join("\n");
 }
 
 // ── Fetch all tickers ───────────────────────────────────────────────
-export async function fetchAllPrices(
-  tickers: string[]
-): Promise<Record<string, QuoteData>> {
+export async function fetchAllPrices(tickers: string[]): Promise<Record<string, QuoteData>> {
   console.log(`Fetching prices for ${tickers.length} tickers...`);
 
   const results: Record<string, QuoteData> = {};
@@ -287,18 +324,14 @@ export async function fetchAllPrices(
           (data.fiftyTwoWeekPercent != null
             ? ` 52w=${(data.fiftyTwoWeekPercent * 100).toFixed(0)}%`
             : "") +
-          (data.dividendYield != null
-            ? ` div=${(data.dividendYield * 100).toFixed(2)}%`
-            : "") +
+          (data.dividendYield != null ? ` div=${(data.dividendYield * 100).toFixed(2)}%` : "") +
           (data.beta != null ? ` β=${data.beta.toFixed(2)}` : "") +
           (data.returnOnEquity != null ? ` ROE=${(data.returnOnEquity * 100).toFixed(0)}%` : "") +
-          (data.holdings != null ? ` [${data.holdings.length} holdings]` : "")
+          (data.holdings != null ? ` [${data.holdings.length} holdings]` : ""),
       );
     }
   }
 
-  console.log(
-    `Fetched ${Object.keys(results).length}/${tickers.length} tickers\n`
-  );
+  console.log(`Fetched ${Object.keys(results).length}/${tickers.length} tickers\n`);
   return results;
 }

--- a/src/fetchTechnicals.ts
+++ b/src/fetchTechnicals.ts
@@ -11,10 +11,10 @@ export interface TechnicalData {
   sma50: number;
   sma200: number | null;
   rsi14: number;
-  priceVsSma50: number;       // % above/below 50MA
+  priceVsSma50: number; // % above/below 50MA
   priceVsSma200: number | null;
-  goldenCross: boolean;       // 50MA > 200MA
-  deathCross: boolean;        // 50MA < 200MA
+  goldenCross: boolean; // 50MA > 200MA
+  deathCross: boolean; // 50MA < 200MA
   momentumSignal: "bullish" | "bearish" | "neutral";
   recentLow7d: number;
   recentLow30d: number;
@@ -22,21 +22,21 @@ export interface TechnicalData {
   // MACD (EMA12 - EMA26, signal = EMA9 of MACD)
   macd: number | null;
   macdSignal: number | null;
-  macdHistogram: number | null;       // macd - signal (positive = bullish momentum)
+  macdHistogram: number | null; // macd - signal (positive = bullish momentum)
   macdCrossover: "bullish" | "bearish" | null; // recent crossover direction
   // Bollinger Bands (SMA20 ± 2σ)
   bollUpper: number | null;
-  bollMiddle: number | null;          // SMA20
+  bollMiddle: number | null; // SMA20
   bollLower: number | null;
-  bollPercentB: number | null;        // 0 = at lower band, 1 = at upper band
-  bollBandwidth: number | null;       // (upper-lower)/middle — volatility measure
-  bollSqueeze: boolean;               // bandwidth in bottom 20% of 120-day range
+  bollPercentB: number | null; // 0 = at lower band, 1 = at upper band
+  bollBandwidth: number | null; // (upper-lower)/middle — volatility measure
+  bollSqueeze: boolean; // bandwidth in bottom 20% of 120-day range
   // ATR (Average True Range, 14-period) — volatility measure
   atr14: number | null;
-  atrPercent: number | null;          // ATR as % of current price
+  atrPercent: number | null; // ATR as % of current price
   // Stochastic Oscillator (%K 14, %D 3)
-  stochK: number | null;             // 0-100, <20 oversold, >80 overbought
-  stochD: number | null;             // 3-period SMA of %K
+  stochK: number | null; // 0-100, <20 oversold, >80 overbought
+  stochD: number | null; // 3-period SMA of %K
   // OBV (On-Balance Volume) trend
   obvTrend: "rising" | "falling" | "flat" | null;
 }
@@ -84,7 +84,9 @@ function computeEMA(prices: number[], period: number): number[] {
 }
 
 function computeMACD(closes: number[]): {
-  macd: number; signal: number; histogram: number;
+  macd: number;
+  signal: number;
+  histogram: number;
   crossover: "bullish" | "bearish" | null;
 } | null {
   if (closes.length < 35) return null; // need 26 + 9 minimum
@@ -119,8 +121,12 @@ function computeMACD(closes: number[]): {
 }
 
 function computeBollinger(closes: number[]): {
-  upper: number; middle: number; lower: number;
-  percentB: number; bandwidth: number; squeeze: boolean;
+  upper: number;
+  middle: number;
+  lower: number;
+  percentB: number;
+  bandwidth: number;
+  squeeze: boolean;
 } | null {
   if (closes.length < 20) return null;
   const period = 20;
@@ -165,12 +171,12 @@ function computeBollinger(closes: number[]): {
 
 function computeATR(
   quotes: { high: number | null; low: number | null; close: number | null }[],
-  period: number = 14
+  period: number = 14,
 ): { atr: number; atrPercent: number } | null {
   // Filter valid OHLC data
   const valid = quotes.filter(
     (q): q is { high: number; low: number; close: number } =>
-      q.high != null && q.low != null && q.close != null
+      q.high != null && q.low != null && q.close != null,
   );
   if (valid.length < period + 1) return null;
 
@@ -179,7 +185,7 @@ function computeATR(
     const tr = Math.max(
       valid[i].high - valid[i].low,
       Math.abs(valid[i].high - valid[i - 1].close),
-      Math.abs(valid[i].low - valid[i - 1].close)
+      Math.abs(valid[i].low - valid[i - 1].close),
     );
     trs.push(tr);
   }
@@ -200,11 +206,11 @@ function computeATR(
 function computeStochastic(
   quotes: { high: number | null; low: number | null; close: number | null }[],
   kPeriod: number = 14,
-  dPeriod: number = 3
+  dPeriod: number = 3,
 ): { k: number; d: number } | null {
   const valid = quotes.filter(
     (q): q is { high: number; low: number; close: number } =>
-      q.high != null && q.low != null && q.close != null
+      q.high != null && q.low != null && q.close != null,
   );
   if (valid.length < kPeriod + dPeriod - 1) return null;
 
@@ -230,11 +236,11 @@ function computeStochastic(
 
 function computeOBVTrend(
   quotes: { close: number | null; volume: number | null }[],
-  trendPeriod: number = 10
+  trendPeriod: number = 10,
 ): "rising" | "falling" | "flat" | null {
   const valid = quotes.filter(
     (q): q is { close: number; volume: number } =>
-      q.close != null && q.volume != null && q.volume > 0
+      q.close != null && q.volume != null && q.volume > 0,
   );
   if (valid.length < trendPeriod + 1) return null;
 
@@ -289,13 +295,13 @@ async function fetchOne(ticker: string): Promise<TechnicalData | null> {
 
     const quotes = result.quotes;
     if (!quotes || quotes.length < 50) {
-      console.warn(`  ⚠ ${ticker}: insufficient chart data (${quotes?.length ?? 0} days), skipping technicals`);
+      console.warn(
+        `  ⚠ ${ticker}: insufficient chart data (${quotes?.length ?? 0} days), skipping technicals`,
+      );
       return null;
     }
 
-    const closes = quotes
-      .map((q) => q.close)
-      .filter((c): c is number => c != null);
+    const closes = quotes.map((q) => q.close).filter((c): c is number => c != null);
 
     if (closes.length < 50) {
       console.warn(`  ⚠ ${ticker}: insufficient closing prices, skipping technicals`);
@@ -308,9 +314,7 @@ async function fetchOne(ticker: string): Promise<TechnicalData | null> {
     const rsi14 = computeRSI(closes) ?? 50;
 
     const priceVsSma50 = ((currentPrice - sma50) / sma50) * 100;
-    const priceVsSma200 = sma200 != null
-      ? ((currentPrice - sma200) / sma200) * 100
-      : null;
+    const priceVsSma200 = sma200 != null ? ((currentPrice - sma200) / sma200) * 100 : null;
 
     const goldenCross = sma200 != null && sma50 > sma200;
     const deathCross = sma200 != null && sma50 < sma200;
@@ -330,9 +334,7 @@ async function fetchOne(ticker: string): Promise<TechnicalData | null> {
     const recentLow30d = Math.min(...last30);
 
     // Volume change: avg 7d vs prior 30d (for bottom-fishing model)
-    const volumes = quotes
-      .map((q) => q.volume)
-      .filter((v): v is number => v != null && v > 0);
+    const volumes = quotes.map((q) => q.volume).filter((v): v is number => v != null && v > 0);
 
     let volumeChange7d: number | null = null;
     if (volumes.length >= 37) {
@@ -396,9 +398,7 @@ async function fetchOne(ticker: string): Promise<TechnicalData | null> {
 }
 
 // ── Fetch technicals for all tickers ────────────────────────────────
-export async function fetchTechnicals(
-  tickers: string[]
-): Promise<Record<string, TechnicalData>> {
+export async function fetchTechnicals(tickers: string[]): Promise<Record<string, TechnicalData>> {
   console.log(`Fetching technicals for ${tickers.length} tickers...`);
 
   const results: Record<string, TechnicalData> = {};
@@ -415,19 +415,21 @@ export async function fetchTechnicals(
           (data.goldenCross ? " ✨golden" : "") +
           (data.deathCross ? " ☠️death" : "") +
           (data.macdCrossover ? ` MACD:${data.macdCrossover}` : "") +
-          (data.macdHistogram != null ? ` hist${data.macdHistogram > 0 ? "+" : ""}${data.macdHistogram}` : "") +
+          (data.macdHistogram != null
+            ? ` hist${data.macdHistogram > 0 ? "+" : ""}${data.macdHistogram}`
+            : "") +
           (data.bollPercentB != null ? ` %B=${data.bollPercentB}` : "") +
           (data.bollSqueeze ? " 🔸squeeze" : "") +
           (data.atrPercent != null ? ` ATR${data.atrPercent}%` : "") +
           (data.stochK != null ? ` Stoch${data.stochK}` : "") +
           (data.obvTrend != null ? ` OBV:${data.obvTrend}` : "") +
-          (data.volumeChange7d != null ? ` vol${data.volumeChange7d > 0 ? "+" : ""}${data.volumeChange7d}%` : "")
+          (data.volumeChange7d != null
+            ? ` vol${data.volumeChange7d > 0 ? "+" : ""}${data.volumeChange7d}%`
+            : ""),
       );
     }
   }
 
-  console.log(
-    `Technicals fetched for ${Object.keys(results).length}/${tickers.length} tickers\n`
-  );
+  console.log(`Technicals fetched for ${Object.keys(results).length}/${tickers.length} tickers\n`);
   return results;
 }

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -5,8 +5,16 @@ import type { AllocationReport } from "./analyze.js";
 
 // Short-duration bond ETFs — duplicated from aiAnalysis.ts for guard independence
 const SHORT_DURATION_BOND_ETFS = new Set([
-  "BSV", "SHY", "VGSH", "SCHO", "BIL", "SHV", "CLTL", "SGOV",
-  "VCSH", "USIG",
+  "BSV",
+  "SHY",
+  "VGSH",
+  "SCHO",
+  "BIL",
+  "SHV",
+  "CLTL",
+  "SGOV",
+  "VCSH",
+  "USIG",
 ]);
 
 /**
@@ -19,7 +27,7 @@ export function validateRecommendations(
   recs: AIBuyRecommendation[],
   priceData: Record<string, QuoteData>,
   technicals: Record<string, TechnicalData>,
-  report: AllocationReport
+  report: AllocationReport,
 ): void {
   guardBondETFCap(recs, report);
   guardEarningsProximity(recs, priceData);
@@ -70,7 +78,7 @@ function guardBondETFCap(recs: AIBuyRecommendation[], report?: AllocationReport)
 // ── Guard 2: Earnings proximity ────────────────────────────────────
 function guardEarningsProximity(
   recs: AIBuyRecommendation[],
-  priceData: Record<string, QuoteData>
+  priceData: Record<string, QuoteData>,
 ): void {
   for (const rec of recs) {
     const quote = priceData[rec.ticker];
@@ -95,7 +103,7 @@ function guardEarningsProximity(
 function guardStrongBuyCriteria(
   recs: AIBuyRecommendation[],
   report: AllocationReport,
-  technicals: Record<string, TechnicalData>
+  technicals: Record<string, TechnicalData>,
 ): void {
   const gapMap: Record<string, number> = {};
   for (const item of report.items) {
@@ -126,8 +134,11 @@ function guardStrongBuyCriteria(
     // this guard only catches obvious misses (no signals at all).
     // We can't perfectly verify P/E signals here without avgPE data.
     if (tech) {
-      const priceBelow200MA = tech.sma200 != null && tech.priceVsSma200 != null && tech.priceVsSma200 < 0;
-      const hasAnyMomentum = tech.rsi14 < 35 || tech.macdCrossover === "bullish" ||
+      const priceBelow200MA =
+        tech.sma200 != null && tech.priceVsSma200 != null && tech.priceVsSma200 < 0;
+      const hasAnyMomentum =
+        tech.rsi14 < 35 ||
+        tech.macdCrossover === "bullish" ||
         (tech.bollPercentB != null && tech.bollPercentB < 0.15) ||
         (tech.stochK != null && tech.stochK < 20);
       // Only downgrade if there are truly NO signals at all
@@ -142,7 +153,7 @@ function guardStrongBuyCriteria(
 // ── Guard 4: Max 2 STRONG BUY ──────────────────────────────────────
 function guardMaxStrongBuy(recs: AIBuyRecommendation[]): void {
   const strongBuys = recs
-    .filter(r => r.action === "STRONG BUY")
+    .filter((r) => r.action === "STRONG BUY")
     .sort((a, b) => b.confidence - a.confidence);
 
   if (strongBuys.length > 2) {
@@ -160,17 +171,16 @@ function guardConfidenceSanity(recs: AIBuyRecommendation[]): void {
       rec.confidence = 95;
     }
     if ((rec.action === "HOLD" || rec.action === "WAIT") && rec.confidence > 70) {
-      console.log(`  [guard:sanity] ${rec.ticker}: ${rec.action} with ${rec.confidence}% → capping at 70%`);
+      console.log(
+        `  [guard:sanity] ${rec.ticker}: ${rec.action} with ${rec.confidence}% → capping at 70%`,
+      );
       rec.confidence = 70;
     }
   }
 }
 
 // ── Guard 6: Buy value sanity ──────────────────────────────────────
-function guardBuyValueSanity(
-  recs: AIBuyRecommendation[],
-  report: AllocationReport
-): void {
+function guardBuyValueSanity(recs: AIBuyRecommendation[], report: AllocationReport): void {
   const gapValueMap: Record<string, number> = {};
   for (const item of report.items) {
     gapValueMap[item.ticker] = item.suggestedBuyValue;
@@ -190,7 +200,9 @@ function guardBuyValueSanity(
 
     const maxGap = gapValueMap[rec.ticker] ?? 0;
     if (maxGap > 0 && rec.suggestedBuyValue > maxGap * 1.1) {
-      console.log(`  [guard:value] ${rec.ticker}: suggestedBuyValue $${rec.suggestedBuyValue.toFixed(0)} > gap $${maxGap.toFixed(0)} → capping`);
+      console.log(
+        `  [guard:value] ${rec.ticker}: suggestedBuyValue $${rec.suggestedBuyValue.toFixed(0)} > gap $${maxGap.toFixed(0)} → capping`,
+      );
       rec.suggestedBuyValue = maxGap;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,12 @@ import type { NewsItem } from "./fetchNews.js";
 import { runAnalysis } from "./analyze.js";
 import { aiAnalyze } from "./aiAnalysis.js";
 import { sendBrief } from "./email.js";
-import { sendTelegramBrief, sendWeeklyTelegram, sendIntradayTelegram, sendRefreshTelegram } from "./telegram.js";
+import {
+  sendTelegramBrief,
+  sendWeeklyTelegram,
+  sendIntradayTelegram,
+  sendRefreshTelegram,
+} from "./telegram.js";
 import { getLatestPrice } from "./fetchPrices.js";
 import { sendWeeklyBrief } from "./weeklyEmail.js";
 import { saveBaseline, loadBaseline, loadReasoningHistory, saveReasoningHistory } from "./state.js";
@@ -25,7 +30,7 @@ async function enrichStrongBuysWithAnalysis(
   prices: Record<string, QuoteData>,
   technicals: Record<string, TechnicalData>,
   report: AllocationReport,
-  macroContext: string = ""
+  macroContext: string = "",
 ): Promise<void> {
   const strongBuys = aiRecs.filter((r) => r.action === "STRONG BUY");
   if (strongBuys.length === 0) return;
@@ -36,7 +41,7 @@ async function enrichStrongBuysWithAnalysis(
     technicals,
     aiRecs,
     report,
-    macroContext
+    macroContext,
   );
 
   for (const rec of strongBuys) {
@@ -86,7 +91,8 @@ const isWeekly = process.argv.includes("--weekly");
 const isIntraday = process.argv.includes("--intraday");
 const isRefresh = process.argv.includes("--refresh");
 const refreshTickerRaw = isRefresh ? process.argv[process.argv.length - 1] : null;
-const refreshTicker = refreshTickerRaw && !refreshTickerRaw.startsWith("-") ? refreshTickerRaw.toUpperCase() : null;
+const refreshTicker =
+  refreshTickerRaw && !refreshTickerRaw.startsWith("-") ? refreshTickerRaw.toUpperCase() : null;
 
 try {
   const tickers = allUniqueTickers();
@@ -108,7 +114,9 @@ try {
   // Log overlap discounts
   for (const item of report.items) {
     if (item.overlapDiscount > 0) {
-      console.log(`  ETF overlap: ${item.ticker} -$${item.overlapDiscount.toFixed(0)} (${item.overlapPct.toFixed(0)}%)`);
+      console.log(
+        `  ETF overlap: ${item.ticker} -$${item.overlapDiscount.toFixed(0)} (${item.overlapPct.toFixed(0)}%)`,
+      );
     }
   }
 
@@ -157,7 +165,9 @@ try {
     console.log(`Price: $${quote.price.toFixed(2)} (${latest.source})`);
     console.log(`Reason: ${targetRec.reason}`);
     if (targetRec.suggestedLimitPrice) {
-      console.log(`Limit: $${targetRec.suggestedLimitPrice.toFixed(2)}${targetRec.limitPriceReason ? " — " + targetRec.limitPriceReason : ""}`);
+      console.log(
+        `Limit: $${targetRec.suggestedLimitPrice.toFixed(2)}${targetRec.limitPriceReason ? " — " + targetRec.limitPriceReason : ""}`,
+      );
     }
     if (targetRec.suggestedBuyValue > 0) {
       console.log(`Suggested buy: $${targetRec.suggestedBuyValue.toFixed(0)}`);
@@ -225,7 +235,7 @@ try {
       console.log(`\n${alerts.length} signal(s) strengthened:`);
       for (const a of alerts) {
         console.log(
-          `  ${a.ticker}: ${a.morningAction} ${a.morningConfidence}% → ${a.currentAction} ${a.currentConfidence}% (${a.triggerType})`
+          `  ${a.ticker}: ${a.morningAction} ${a.morningConfidence}% → ${a.currentAction} ${a.currentConfidence}% (${a.triggerType})`,
         );
       }
 
@@ -252,7 +262,14 @@ try {
       fetchTechnicals(tickers),
     ]);
     const reasoningHistory = loadReasoningHistory();
-    const aiRecs = await aiAnalyze(report, prices, news, technicals, macroContext, reasoningHistory);
+    const aiRecs = await aiAnalyze(
+      report,
+      prices,
+      news,
+      technicals,
+      macroContext,
+      reasoningHistory,
+    );
 
     // Generate detailed analysis + "More Details" URLs for STRONG BUY tickers
     await enrichStrongBuysWithAnalysis(aiRecs, prices, technicals, report, macroContext);

--- a/src/intradayCompare.ts
+++ b/src/intradayCompare.ts
@@ -5,6 +5,7 @@ import type { IntradayAlertConfig } from "./config.js";
 // ── Types ───────────────────────────────────────────────────────────
 export interface IntradayAlert {
   ticker: string;
+  tickerFullName: string | null;
   morningAction: string;
   morningConfidence: number;
   currentAction: string;
@@ -36,13 +37,11 @@ export function compareWithBaseline(
   currentRecs: AIBuyRecommendation[],
   currentPrices: Record<string, number>,
   baseline: MorningBaseline,
-  config: IntradayAlertConfig
+  config: IntradayAlertConfig,
 ): IntradayAlert[] {
   const alerts: IntradayAlert[] = [];
 
-  const baselineMap = new Map(
-    baseline.recommendations.map((r) => [r.ticker, r])
-  );
+  const baselineMap = new Map(baseline.recommendations.map((r) => [r.ticker, r]));
 
   for (const rec of currentRecs) {
     const morning = baselineMap.get(rec.ticker);
@@ -77,13 +76,18 @@ export function compareWithBaseline(
     }
 
     // Skip alerts below minimum confidence threshold
-    if (triggerType && triggerType !== "action_downgrade" && rec.confidence < config.minConfidenceToAlert) {
+    if (
+      triggerType &&
+      triggerType !== "action_downgrade" &&
+      rec.confidence < config.minConfidenceToAlert
+    ) {
       triggerType = null;
     }
 
     if (triggerType) {
       alerts.push({
         ticker: rec.ticker,
+        tickerFullName: rec.tickerFullName ?? null,
         morningAction,
         morningConfidence,
         currentAction: rec.action,
@@ -99,10 +103,7 @@ export function compareWithBaseline(
         triggerType,
         currentPrice,
         morningPrice,
-        priceDelta:
-          morningPrice > 0
-            ? ((currentPrice - morningPrice) / morningPrice) * 100
-            : 0,
+        priceDelta: morningPrice > 0 ? ((currentPrice - morningPrice) / morningPrice) * 100 : 0,
       });
     }
   }

--- a/src/intradayEmail.ts
+++ b/src/intradayEmail.ts
@@ -3,6 +3,7 @@ import { recipientEmail } from "./config.js";
 import type { IntradayAlert } from "./intradayCompare.js";
 import type { AIBuyRecommendation } from "./aiAnalysis.js";
 import type { QuoteData } from "./fetchPrices.js";
+import { escapeHtmlAttr } from "./util.js";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -60,7 +61,12 @@ function priceDeltaHtml(delta: number): string {
   return `<span style="color:${color};font-size:12px;">Price ${sign}${delta.toFixed(1)}% since morning</span>`;
 }
 
-const ratingColors: Record<string, string> = { A: "#2ecc71", B: "#3498db", C: "#f39c12", D: "#e74c3c" };
+const ratingColors: Record<string, string> = {
+  A: "#2ecc71",
+  B: "#3498db",
+  C: "#f39c12",
+  D: "#e74c3c",
+};
 
 function valueRatingBadge(rating: string | undefined): string {
   if (!rating || rating === "") return "";
@@ -70,10 +76,14 @@ function valueRatingBadge(rating: string | undefined): string {
 
 function summarizeAlertDirection(alerts: IntradayAlert[]): string {
   const hasStrengthened = alerts.some(
-    (a) => a.triggerType === "action_upgrade" || (a.triggerType === "confidence_change" && a.confidenceDelta > 0)
+    (a) =>
+      a.triggerType === "action_upgrade" ||
+      (a.triggerType === "confidence_change" && a.confidenceDelta > 0),
   );
   const hasWeakened = alerts.some(
-    (a) => a.triggerType === "action_downgrade" || (a.triggerType === "confidence_change" && a.confidenceDelta < 0)
+    (a) =>
+      a.triggerType === "action_downgrade" ||
+      (a.triggerType === "confidence_change" && a.confidenceDelta < 0),
   );
   if (hasStrengthened && hasWeakened) return "changed";
   if (hasWeakened) return "weakened";
@@ -99,7 +109,7 @@ export function buildIntradayEmailHtml(alerts: IntradayAlert[]): string {
       (a) => `
   <div style="padding:14px 0;border-bottom:1px solid ${S.border};">
     <div style="margin-bottom:6px;">
-      <span style="font-weight:bold;font-size:16px;color:#fff;">${a.ticker}</span>
+      <span style="font-weight:bold;font-size:16px;color:#fff;" title="${escapeHtmlAttr(a.tickerFullName ?? a.ticker)}">${a.ticker}</span>
       &nbsp;${actionBadge(a.currentAction)}${valueRatingBadge(a.valueRating)}
       <span style="float:right;font-size:11px;color:${S.yellow};text-transform:uppercase;">${triggerLabel(a.triggerType)}</span>
     </div>
@@ -116,7 +126,7 @@ export function buildIntradayEmailHtml(alerts: IntradayAlert[]): string {
     ${a.currentAction === "STRONG BUY" && a.suggestedLimitPrice && a.suggestedLimitPrice > 0 ? `<div style="font-size:12px;color:${S.green};margin-top:4px;">Limit order: $${a.suggestedLimitPrice.toFixed(2)}${a.limitPriceReason ? ` — ${a.limitPriceReason}` : ""}</div>` : ""}
     ${a.bottomSignal && a.bottomSignal !== "" ? `<div style="font-size:11px;color:${S.yellow};margin-top:4px;">Bottom signal: ${a.bottomSignal}</div>` : ""}
     ${a.currentAction === "STRONG BUY" && a.analysisUrl ? `<div style="margin-top:8px;"><a href="${a.analysisUrl}" style="display:inline-block;background:#3498db22;color:#3498db;padding:4px 12px;border-radius:4px;font-size:11px;font-weight:bold;text-decoration:none;border:1px solid #3498db44;">More Details &rarr;</a></div>` : ""}
-  </div>`
+  </div>`,
     )
     .join("");
 
@@ -151,9 +161,7 @@ export function buildIntradayEmailHtml(alerts: IntradayAlert[]): string {
 }
 
 // ── Send email ──────────────────────────────────────────────────────
-export async function sendIntradayAlert(
-  alerts: IntradayAlert[]
-): Promise<void> {
+export async function sendIntradayAlert(alerts: IntradayAlert[]): Promise<void> {
   const html = buildIntradayEmailHtml(alerts);
   const tickers = alerts.map((a) => a.ticker).join(", ");
 
@@ -176,10 +184,19 @@ export async function sendRefreshEmail(
   ticker: string,
   rec: AIBuyRecommendation,
   quote: QuoteData,
-  priceSource: string
+  priceSource: string,
 ): Promise<void> {
-  const time = new Date().toLocaleTimeString("en-AU", { hour: "2-digit", minute: "2-digit", hour12: true });
-  const date = new Date().toLocaleDateString("en-AU", { weekday: "long", day: "numeric", month: "short", year: "numeric" });
+  const time = new Date().toLocaleTimeString("en-AU", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  });
+  const date = new Date().toLocaleDateString("en-AU", {
+    weekday: "long",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
 
   const html = `<!DOCTYPE html>
 <html>
@@ -197,7 +214,7 @@ export async function sendRefreshEmail(
 <!-- Content -->
 <tr><td style="padding:16px 24px;background:${S.cardBg};">
   <div style="margin-bottom:10px;">
-    <span style="font-weight:bold;font-size:18px;color:#fff;">${ticker}</span>
+    <span style="font-weight:bold;font-size:18px;color:#fff;" title="${escapeHtmlAttr(quote.longName ?? ticker)}">${ticker}</span>
     &nbsp;${actionBadge(rec.action)}${rec.valueRating ? valueRatingBadge(rec.valueRating) : ""}
   </div>
   <div style="font-size:13px;color:#fff;margin-bottom:6px;">Confidence: <strong>${rec.confidence}%</strong></div>

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,9 +35,7 @@ export function saveBaseline(baseline: MorningBaseline): void {
     mkdirSync(STATE_DIR, { recursive: true });
   }
   writeFileSync(BASELINE_FILE, JSON.stringify(baseline, null, 2));
-  console.log(
-    `Morning baseline saved (${baseline.recommendations.length} recs)`
-  );
+  console.log(`Morning baseline saved (${baseline.recommendations.length} recs)`);
 }
 
 export function loadBaseline(): MorningBaseline | null {
@@ -47,12 +45,9 @@ export function loadBaseline(): MorningBaseline | null {
 
     // Check baseline age instead of date string — works across any timezone
     // (daily at 10pm UTC + intraday at 0-6am UTC straddles midnight in many TZs)
-    const ageHours =
-      (Date.now() - new Date(data.timestamp).getTime()) / (1000 * 60 * 60);
+    const ageHours = (Date.now() - new Date(data.timestamp).getTime()) / (1000 * 60 * 60);
     if (ageHours > 18) {
-      console.log(
-        `Baseline is ${ageHours.toFixed(1)}h old (max 18h) — skipping comparison`
-      );
+      console.log(`Baseline is ${ageHours.toFixed(1)}h old (max 18h) — skipping comparison`);
       return null;
     }
 
@@ -65,7 +60,7 @@ export function loadBaseline(): MorningBaseline | null {
 // ── Reasoning History ──────────────────────────────────────────────
 export function saveReasoningHistory(
   recs: AIBuyRecommendation[],
-  prices: Record<string, number>
+  prices: Record<string, number>,
 ): void {
   if (!existsSync(STATE_DIR)) {
     mkdirSync(STATE_DIR, { recursive: true });
@@ -113,7 +108,10 @@ export function formatReasoningContext(history: ReasoningHistory): string {
   if (dates.length === 0) return "";
 
   // Collect per-ticker history across days
-  const tickerHistory: Record<string, { date: string; action: string; confidence: number; price: number }[]> = {};
+  const tickerHistory: Record<
+    string,
+    { date: string; action: string; confidence: number; price: number }[]
+  > = {};
   for (const date of dates) {
     for (const snap of history.snapshots[date]) {
       if (!tickerHistory[snap.ticker]) tickerHistory[snap.ticker] = [];
@@ -130,16 +128,21 @@ export function formatReasoningContext(history: ReasoningHistory): string {
   const lines: string[] = ["HISTORICAL CONTEXT (AI conviction over last 7 days):"];
   for (const [ticker, entries] of Object.entries(tickerHistory)) {
     if (entries.length < 2) continue;
-    const trend = entries.map((e) => `${e.action} ${e.confidence}% ($${e.price.toFixed(0)})`).join(" → ");
+    const trend = entries
+      .map((e) => `${e.action} ${e.confidence}% ($${e.price.toFixed(0)})`)
+      .join(" → ");
     // Determine trend direction
     const first = entries[0].confidence;
     const last = entries[entries.length - 1].confidence;
-    const direction = last > first + 5 ? "— strengthening" : last < first - 5 ? "— weakening" : "— stable";
+    const direction =
+      last > first + 5 ? "— strengthening" : last < first - 5 ? "— weakening" : "— stable";
     lines.push(`  ${ticker}: ${trend} ${direction}`);
   }
 
   if (lines.length === 1) return ""; // No multi-day history
   lines.push("");
-  lines.push("Use this to identify conviction momentum. Strengthening 3+ days confirms the trend. Weakening suggests caution.");
+  lines.push(
+    "Use this to identify conviction momentum. Strengthening 3+ days confirms the trend. Weakening suggests caution.",
+  );
   return lines.join("\n");
 }

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -4,6 +4,7 @@ import type { NewsItem } from "./fetchNews.js";
 import type { TechnicalData } from "./fetchTechnicals.js";
 import type { IntradayAlert } from "./intradayCompare.js";
 import type { QuoteData } from "./fetchPrices.js";
+import { escapeHtmlText } from "./util.js";
 
 const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const CHAT_ID = process.env.TELEGRAM_CHAT_ID;
@@ -17,11 +18,16 @@ function fmt$(n: number): string {
 
 function actionEmoji(action: string): string {
   switch (action) {
-    case "STRONG BUY": return "🟢";
-    case "BUY": return "🔵";
-    case "HOLD": return "⚪";
-    case "WAIT": return "🔴";
-    default: return "⚪";
+    case "STRONG BUY":
+      return "🟢";
+    case "BUY":
+      return "🔵";
+    case "HOLD":
+      return "⚪";
+    case "WAIT":
+      return "🔴";
+    default:
+      return "⚪";
   }
 }
 
@@ -31,7 +37,7 @@ function buildMessage(
   news: Record<string, NewsItem[]>,
   aiRecs: AIBuyRecommendation[],
   technicals: Record<string, TechnicalData> = {},
-  priceData: Record<string, QuoteData> = {}
+  priceData: Record<string, QuoteData> = {},
 ): string {
   const date = new Date().toLocaleDateString("en-AU", {
     weekday: "long",
@@ -47,24 +53,27 @@ function buildMessage(
   lines.push("");
   lines.push(
     `💰 <b>${fmt$(report.totalCurrentValue)}</b>` +
-    (report.portfolioBeta != null ? `  |  β ${report.portfolioBeta.toFixed(2)}` : "") +
-    `  |  📈 ${fmt$(report.estimatedAnnualDividend)}/yr div`
+      (report.portfolioBeta != null ? `  |  β ${report.portfolioBeta.toFixed(2)}` : "") +
+      `  |  📈 ${fmt$(report.estimatedAnnualDividend)}/yr div`,
   );
   lines.push("");
 
   // AI Recommendations or fallback
   if (aiRecs.length > 0) {
-    const actionable = aiRecs.filter(r => r.action === "STRONG BUY" || r.action === "BUY").slice(0, 5);
+    const actionable = aiRecs
+      .filter((r) => r.action === "STRONG BUY" || r.action === "BUY")
+      .slice(0, 5);
     if (actionable.length > 0) {
       lines.push("🤖 <b>AI Recommendations:</b>");
       for (const rec of actionable) {
         const earningsDays = priceData[rec.ticker]?.daysToEarnings;
-        const earningsTag = earningsDays != null && earningsDays <= 14 ? ` [earnings ${earningsDays}d]` : "";
+        const earningsTag =
+          earningsDays != null && earningsDays <= 14 ? ` [earnings ${earningsDays}d]` : "";
         lines.push(
           `${actionEmoji(rec.action)} <b>${rec.action} ${rec.ticker}</b> (${rec.confidence}%)` +
-          (rec.valueRating ? ` [${rec.valueRating}]` : "") +
-          earningsTag +
-          (rec.suggestedBuyValue > 0 ? ` — ${fmt$(rec.suggestedBuyValue)}` : "")
+            (rec.valueRating ? ` [${rec.valueRating}]` : "") +
+            earningsTag +
+            (rec.suggestedBuyValue > 0 ? ` — ${fmt$(rec.suggestedBuyValue)}` : ""),
         );
         lines.push(`   <i>${rec.reason}</i>`);
         // Technical insight for STRONG BUY only
@@ -73,15 +82,19 @@ function buildMessage(
           if (tech) {
             lines.push(
               `   📈 ${tech.momentumSignal} · RSI ${tech.rsi14} · 50MA $${tech.sma50} (${tech.priceVsSma50 > 0 ? "+" : ""}${tech.priceVsSma50}%)` +
-              (tech.macdCrossover ? ` · MACD ${tech.macdCrossover}` : tech.macdHistogram != null ? ` · MACD hist ${tech.macdHistogram > 0 ? "+" : ""}${tech.macdHistogram}` : "") +
-              (tech.bollPercentB != null ? ` · %B ${tech.bollPercentB}` : "") +
-              (tech.bollSqueeze ? " · 🔸squeeze" : "")
+                (tech.macdCrossover
+                  ? ` · MACD ${tech.macdCrossover}`
+                  : tech.macdHistogram != null
+                    ? ` · MACD hist ${tech.macdHistogram > 0 ? "+" : ""}${tech.macdHistogram}`
+                    : "") +
+                (tech.bollPercentB != null ? ` · %B ${tech.bollPercentB}` : "") +
+                (tech.bollSqueeze ? " · 🔸squeeze" : ""),
             );
           }
           if (rec.suggestedLimitPrice && rec.suggestedLimitPrice > 0) {
             lines.push(
               `   💡 Limit: $${rec.suggestedLimitPrice.toFixed(2)}` +
-              (rec.limitPriceReason ? ` — ${rec.limitPriceReason}` : "")
+                (rec.limitPriceReason ? ` — ${rec.limitPriceReason}` : ""),
             );
           }
           if (rec.bottomSignal && rec.bottomSignal !== "") {
@@ -93,11 +106,11 @@ function buildMessage(
         }
       }
 
-      const holds = aiRecs.filter(r => r.action === "HOLD" || r.action === "WAIT");
+      const holds = aiRecs.filter((r) => r.action === "HOLD" || r.action === "WAIT");
       if (holds.length > 0) {
         lines.push("");
         lines.push(
-          `⏸ Hold/Wait: ${holds.map(r => r.ticker + (r.valueRating ? `[${r.valueRating}]` : "")).join(", ")}`
+          `⏸ Hold/Wait: ${holds.map((r) => r.ticker + (r.valueRating ? `[${r.valueRating}]` : "")).join(", ")}`,
         );
       }
     } else {
@@ -105,13 +118,13 @@ function buildMessage(
     }
   } else {
     // Fallback: gap-based top buys
-    const buys = report.items.filter(i => i.gapPct > 0.5).slice(0, 5);
+    const buys = report.items.filter((i) => i.gapPct > 0.5).slice(0, 5);
     if (buys.length > 0) {
       lines.push("📋 <b>Priority Buys (by gap):</b>");
       for (const b of buys) {
         lines.push(
           `• <b>${b.ticker}</b> — gap +${b.gapPct.toFixed(1)}% — buy ~${fmt$(b.suggestedBuyValue)}` +
-          (b.overlapDiscount > 0 ? ` (−${fmt$(b.overlapDiscount)} overlap)` : "")
+            (b.overlapDiscount > 0 ? ` (−${fmt$(b.overlapDiscount)} overlap)` : ""),
         );
       }
     }
@@ -129,7 +142,7 @@ function buildMessage(
     let newsText = "";
     for (const [ticker, articles] of tickersWithNews) {
       const headline = articles[0]; // 1 per ticker
-      const line = `<b>${ticker}:</b> <a href="${headline.url}">${escapeHtml(headline.title)}</a>\n`;
+      const line = `<b>${ticker}:</b> <a href="${headline.url}">${escapeHtmlText(headline.title)}</a>\n`;
       if (newsText.length + line.length > budgetForNews) break;
       newsText += line;
     }
@@ -139,20 +152,13 @@ function buildMessage(
   return lines.join("\n");
 }
 
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
 // ── Send to Telegram ────────────────────────────────────────────────
 export async function sendTelegramBrief(
   report: AllocationReport,
   news: Record<string, NewsItem[]>,
   aiRecs: AIBuyRecommendation[] = [],
   technicals: Record<string, TechnicalData> = {},
-  priceData: Record<string, QuoteData> = {}
+  priceData: Record<string, QuoteData> = {},
 ): Promise<void> {
   if (!BOT_TOKEN || !CHAT_ID) {
     console.log("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set — skipping Telegram\n");
@@ -196,48 +202,46 @@ function buildWeeklyMessage(report: AllocationReport): string {
   lines.push("");
   lines.push(
     `💰 <b>${fmt$(report.totalCurrentValue)}</b>` +
-    (report.portfolioBeta != null ? `  |  β ${report.portfolioBeta.toFixed(2)}` : "") +
-    `  |  📈 ${fmt$(report.estimatedAnnualDividend)}/yr div`
+      (report.portfolioBeta != null ? `  |  β ${report.portfolioBeta.toFixed(2)}` : "") +
+      `  |  📈 ${fmt$(report.estimatedAnnualDividend)}/yr div`,
   );
 
   // Underweight (buy)
-  const buys = report.items.filter(i => i.gapPct > 0.5);
+  const buys = report.items.filter((i) => i.gapPct > 0.5);
   if (buys.length > 0) {
     lines.push("");
     lines.push("🔴 <b>Underweight — Buy:</b>");
     for (const b of buys) {
       lines.push(
         `• <b>${b.ticker}</b>  ${b.currentPct.toFixed(1)}% → ${b.targetPct.toFixed(1)}%  gap +${b.gapPct.toFixed(1)}%  ~${fmt$(b.suggestedBuyValue)}` +
-        (b.overlapDiscount > 0 ? ` (−${fmt$(b.overlapDiscount)} overlap)` : "")
+          (b.overlapDiscount > 0 ? ` (−${fmt$(b.overlapDiscount)} overlap)` : ""),
       );
     }
   }
 
   // Overweight (sell/trim)
-  const sells = report.items.filter(i => i.gapPct < -1);
+  const sells = report.items.filter((i) => i.gapPct < -1);
   if (sells.length > 0) {
     lines.push("");
     lines.push("🟡 <b>Overweight — Consider Trimming:</b>");
     for (const s of sells) {
       lines.push(
-        `• <b>${s.ticker}</b>  ${s.currentPct.toFixed(1)}% → ${s.targetPct.toFixed(1)}%  gap ${s.gapPct.toFixed(1)}%`
+        `• <b>${s.ticker}</b>  ${s.currentPct.toFixed(1)}% → ${s.targetPct.toFixed(1)}%  gap ${s.gapPct.toFixed(1)}%`,
       );
     }
   }
 
   // On target
-  const onTarget = report.items.filter(i => Math.abs(i.gapPct) <= 1 && i.targetPct > 0);
+  const onTarget = report.items.filter((i) => Math.abs(i.gapPct) <= 1 && i.targetPct > 0);
   if (onTarget.length > 0) {
     lines.push("");
-    lines.push(`✅ On target: ${onTarget.map(i => i.ticker).join(", ")}`);
+    lines.push(`✅ On target: ${onTarget.map((i) => i.ticker).join(", ")}`);
   }
 
   return lines.join("\n");
 }
 
-export async function sendWeeklyTelegram(
-  report: AllocationReport
-): Promise<void> {
+export async function sendWeeklyTelegram(report: AllocationReport): Promise<void> {
   if (!BOT_TOKEN || !CHAT_ID) {
     console.log("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set — skipping Telegram\n");
     return;
@@ -287,16 +291,14 @@ function buildIntradayMessage(alerts: IntradayAlert[]): string {
           : "confidence changed";
 
     lines.push(
-      `${actionEmoji(alert.currentAction)} <b>${alert.currentAction} ${alert.ticker}</b> (${triggerLabel})`
+      `${actionEmoji(alert.currentAction)} <b>${alert.currentAction} ${alert.ticker}</b> (${triggerLabel})`,
     );
     lines.push(
-      `   ${alert.morningAction} ${alert.morningConfidence}% → ${alert.currentAction} ${alert.currentConfidence}% (${alert.confidenceDelta >= 0 ? "+" : ""}${alert.confidenceDelta})`
+      `   ${alert.morningAction} ${alert.morningConfidence}% → ${alert.currentAction} ${alert.currentConfidence}% (${alert.confidenceDelta >= 0 ? "+" : ""}${alert.confidenceDelta})`,
     );
     if (Math.abs(alert.priceDelta) >= 0.01) {
       const dir = alert.priceDelta < 0 ? "down" : "up";
-      lines.push(
-        `   Price ${dir} ${Math.abs(alert.priceDelta).toFixed(1)}% since morning`
-      );
+      lines.push(`   Price ${dir} ${Math.abs(alert.priceDelta).toFixed(1)}% since morning`);
     }
     lines.push(`   <i>${alert.reason}</i>`);
     if (alert.suggestedBuyValue > 0) {
@@ -311,13 +313,9 @@ function buildIntradayMessage(alerts: IntradayAlert[]): string {
   return lines.join("\n").trim();
 }
 
-export async function sendIntradayTelegram(
-  alerts: IntradayAlert[]
-): Promise<void> {
+export async function sendIntradayTelegram(alerts: IntradayAlert[]): Promise<void> {
   if (!BOT_TOKEN || !CHAT_ID) {
-    console.log(
-      "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set — skipping Telegram\n"
-    );
+    console.log("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set — skipping Telegram\n");
     return;
   }
 
@@ -348,7 +346,7 @@ export async function sendRefreshTelegram(
   ticker: string,
   rec: AIBuyRecommendation,
   quote: QuoteData,
-  priceSource: string
+  priceSource: string,
 ): Promise<void> {
   if (!BOT_TOKEN || !CHAT_ID) {
     console.log("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set — skipping Telegram\n");
@@ -368,7 +366,9 @@ export async function sendRefreshTelegram(
   lines.push(`💰 Price: $${quote.price.toFixed(2)} (${priceSource})`);
   lines.push(`<i>${rec.reason}</i>`);
   if (rec.suggestedLimitPrice && rec.suggestedLimitPrice > 0) {
-    lines.push(`💡 Limit: $${rec.suggestedLimitPrice.toFixed(2)}${rec.limitPriceReason ? " — " + rec.limitPriceReason : ""}`);
+    lines.push(
+      `💡 Limit: $${rec.suggestedLimitPrice.toFixed(2)}${rec.limitPriceReason ? " — " + rec.limitPriceReason : ""}`,
+    );
   }
   if (rec.suggestedBuyValue > 0) {
     lines.push(`📊 Suggested: ${fmt$(rec.suggestedBuyValue)}`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,17 @@
+// Escape an arbitrary string so it is safe to embed inside an HTML attribute
+// value (e.g. `title="..."`). Covers the five characters that have special
+// meaning in HTML attributes.
+export function escapeHtmlAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Escape for HTML text content. Telegram's HTML mode only requires the first
+// three replacements; quotes pass through fine in text nodes.
+export function escapeHtmlText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/src/weeklyEmail.ts
+++ b/src/weeklyEmail.ts
@@ -1,6 +1,7 @@
 import { Resend } from "resend";
 import { recipientEmail } from "./config.js";
 import type { AllocationItem, AllocationReport } from "./analyze.js";
+import { escapeHtmlAttr } from "./util.js";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -42,10 +43,10 @@ export function buildWeeklyEmailHtml(report: AllocationReport): string {
     day: "numeric",
   });
 
-  const onTarget = report.items.filter(i => Math.abs(i.gapPct) <= 1 && i.targetPct > 0);
-  const underweight = report.items.filter(i => i.gapPct > 1);
-  const overweight = report.items.filter(i => i.gapPct < -1 && i.targetPct > 0);
-  const noTarget = report.items.filter(i => i.targetPct === 0 && i.currentValue > 0);
+  const onTarget = report.items.filter((i) => Math.abs(i.gapPct) <= 1 && i.targetPct > 0);
+  const underweight = report.items.filter((i) => i.gapPct > 1);
+  const overweight = report.items.filter((i) => i.gapPct < -1 && i.targetPct > 0);
+  const noTarget = report.items.filter((i) => i.targetPct === 0 && i.currentValue > 0);
 
   // All items sorted by |gap| descending for the full table
   const sorted = [...report.items].sort((a, b) => Math.abs(b.gapPct) - Math.abs(a.gapPct));
@@ -75,7 +76,7 @@ export function buildWeeklyEmailHtml(report: AllocationReport): string {
     </td>
     <td style="text-align:center;padding:8px;">
       <div style="font-size:11px;color:${S.muted};text-transform:uppercase;">On Target</div>
-      <div style="font-size:20px;font-weight:bold;color:${S.green};">${onTarget.length}/${report.items.filter(i => i.targetPct > 0).length}</div>
+      <div style="font-size:20px;font-weight:bold;color:${S.green};">${onTarget.length}/${report.items.filter((i) => i.targetPct > 0).length}</div>
     </td>
     <td style="text-align:center;padding:8px;">
       <div style="font-size:11px;color:${S.muted};text-transform:uppercase;">Est. Annual Div</div>
@@ -99,11 +100,13 @@ export function buildWeeklyEmailHtml(report: AllocationReport): string {
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">Gap</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">Amount</td>
     </tr>
-    ${sorted.filter(i => i.targetPct > 0 || i.currentValue > 0).map((item) => {
-      const action = actionLabel(item.gapPct);
-      return `
+    ${sorted
+      .filter((i) => i.targetPct > 0 || i.currentValue > 0)
+      .map((item) => {
+        const action = actionLabel(item.gapPct);
+        return `
     <tr>
-      <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-weight:bold;">${item.ticker}</td>
+      <td style="padding:5px 3px;border-bottom:1px solid ${S.border};font-weight:bold;" title="${escapeHtmlAttr(item.tickerFullName ?? item.ticker)}">${item.ticker}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:center;">
         <span style="background:${action.color};color:#000;padding:1px 6px;border-radius:3px;font-size:10px;font-weight:bold;">${action.text}</span>
       </td>
@@ -112,27 +115,36 @@ export function buildWeeklyEmailHtml(report: AllocationReport): string {
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;color:${action.color};">${fmtPct(item.gapPct)}</td>
       <td style="padding:5px 3px;border-bottom:1px solid ${S.border};text-align:right;">${item.suggestedBuyValue > 0 ? `Buy ${fmt$(item.suggestedBuyValue)}${item.overlapDiscount > 0 ? `<div style="font-size:10px;color:${S.muted};">-${fmt$(item.overlapDiscount)} overlap</div>` : ""}` : "—"}</td>
     </tr>`;
-    }).join("")}
+      })
+      .join("")}
   </table>
 </td></tr>
 
-${overweight.length > 0 ? `
+${
+  overweight.length > 0
+    ? `
 <!-- Overweight Warning -->
 <tr><td style="padding:16px 24px;background:${S.cardBg};border-top:1px solid ${S.border};">
   <h3 style="margin:0;font-size:14px;color:${S.yellow};">⚠ Overweight Positions</h3>
   <p style="margin:4px 0 0;font-size:12px;color:${S.text};">
-    ${overweight.map(i => `<b>${i.ticker}</b> (${i.currentPct.toFixed(1)}% vs ${i.targetPct.toFixed(1)}% target)`).join(", ")}
+    ${overweight.map((i) => `<b>${i.ticker}</b> (${i.currentPct.toFixed(1)}% vs ${i.targetPct.toFixed(1)}% target)`).join(", ")}
   </p>
-</td></tr>` : ""}
+</td></tr>`
+    : ""
+}
 
-${noTarget.length > 0 ? `
+${
+  noTarget.length > 0
+    ? `
 <!-- No-target holdings -->
 <tr><td style="padding:16px 24px;background:${S.cardBg};border-top:1px solid ${S.border};">
   <h3 style="margin:0;font-size:14px;color:${S.muted};">Holdings Not in Target Portfolio</h3>
   <p style="margin:4px 0 0;font-size:12px;color:${S.text};">
-    ${noTarget.map(i => `<b>${i.ticker}</b> (${fmt$(i.currentValue)}, ${i.currentPct.toFixed(1)}%)`).join(", ")}
+    ${noTarget.map((i) => `<b>${i.ticker}</b> (${fmt$(i.currentValue)}, ${i.currentPct.toFixed(1)}%)`).join(", ")}
   </p>
-</td></tr>` : ""}
+</td></tr>`
+    : ""
+}
 
 <!-- Footer -->
 <tr><td style="padding:16px 24px;background:${S.accent};border-radius:0 0 8px 8px;text-align:center;">
@@ -147,9 +159,7 @@ ${noTarget.length > 0 ? `
 }
 
 // ── Send weekly email ───────────────────────────────────────────────
-export async function sendWeeklyBrief(
-  report: AllocationReport
-): Promise<void> {
+export async function sendWeeklyBrief(report: AllocationReport): Promise<void> {
   const html = buildWeeklyEmailHtml(report);
 
   const { error } = await resend.emails.send({


### PR DESCRIPTION
## Summary

- Threads `tickerFullName` (Yahoo `longName`) through the pipeline so email tickers get hover tooltips, and Gemini reasoning text references companies by full name. Supersedes #6 with HTML-attribute-safe escaping (`escapeHtmlAttr` covers `& < > " '`).
- Adds a CI gate (typecheck + Prettier + EditorConfig) so external PRs get automatic style/type signal — none existed before.

## Changes

**Feature (commit 2ec69f9):**
- New `src/util.ts` — shared `escapeHtmlAttr` (5-char) and `escapeHtmlText` (3-char). `telegram.ts` now imports from it.
- New `quote.longName` field — kept `quote.name` priority unchanged (`shortName ?? longName`) so news-search behavior in `fetchNews.ts` is preserved.
- `tickerFullName` plumbed through `analyze.ts` → `aiAnalysis.ts` → `intradayCompare.ts`. Attached to AI recs server-side from price data, not from the model — deterministic.
- 6 `title=` interpolations escaped in `email.ts`, `intradayEmail.ts`, `weeklyEmail.ts`. Refresh email also gets a tooltip via `quote.longName`.
- AI prompts (Stage 1 + `detailedAnalysis.ts`) instruct Gemini to use full names in reasoning.

**Tooling (commit 7c6521f):**
- `.editorconfig`, `.prettierrc.json`, `.prettierignore`
- `package.json` — adds `typecheck`, `format`, `format:check` scripts + `prettier` devDep
- One-time prettier baseline reformat across all 16 src files

**CI (commit dc79874):**
- `.github/workflows/ci.yml` — runs on `pull_request` and `push` to main: `npm ci → typecheck → format:check`. No secrets, no `pull_request_target` (so untrusted fork code never runs with privileged tokens).

**Docs (commit 84ebad9):**
- README badge for the new CI workflow.

## Test plan

- [x] `npm run typecheck` — passes locally
- [x] `npm run format:check` — passes locally
- [x] CI runs on this PR and goes green (`validate` job, 13s)
- [x] Synthetic smoke test (`scratch/smoke-tooltip.ts`, untracked) — fed `MCD` with `"McDonald's Corporation"` plus an adversarial `Foo" onmouseover="alert(1)` name through `buildEmailHtml`. Verified rendered HTML contains `title="McDonald&#39;s Corporation"` at every site (AI rec + allocation table + fallback table) and the injection attempt becomes `title="Foo&quot; onmouseover=&quot;alert(1)"` — quote escaped, no live event handler.
- [x] `npm run dev` end-to-end — Yahoo prices for 18/19 tickers, technicals for 19/19, macro indicators OK. Gemini was 503ing (Google capacity), so fallback gap-based recs path exercised — that's also a tooltip site, confirming wiring works on the fallback branch too. Email + Telegram delivered.
- [ ] Post-merge: open a test fork PR, confirm CI auto-triggers and gates style/type drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)