### PR TITLE
fix(ci): use explicit test path — glob not expanded by sh on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "intraday": "tsx src/index.ts --intraday",
     "refresh": "tsx src/index.ts --refresh",
     "typecheck": "tsc --noEmit",
-    "test": "node --import=tsx/esm --test test/**/*.test.ts",
+    "test": "node --import=tsx/esm --test test/util.test.ts",
     "smoke": "npx tsx smoke/smoke-fx.ts && npx tsx smoke/smoke-conversion.ts && npx tsx smoke/smoke-money-format.ts",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\""


### PR DESCRIPTION
## Summary

- The `npm test` script used `test/**/*.test.ts` which relies on shell glob expansion
- On Linux CI (`sh`), `**` globbing requires `globstar` (a bash extension) — `sh` passes it as a literal path and Node can't find it
- Fixed by using the explicit path `test/util.test.ts` (as long as we have one test file this is the right approach; add new files explicitly as the suite grows)

## Test plan

- [ ] CI `validate` job passes (typecheck + format:check + unit tests)
- [ ] `npm run dev` with TSCO.L (GBp) + SAP.DE (EUR) added to `targetPortfolio` — verify header shows `· USD`, prices are USD-magnitude, footer caveat appears, original currencies logged in console
- [ ] Revert config

Closes the CI failure from the squash-merge of #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)